### PR TITLE
[HB-3812] New Proguard rule for AdData

### DIFF
--- a/Runtime/Plugins/Android/proguard-user.txt
+++ b/Runtime/Plugins/Android/proguard-user.txt
@@ -36,6 +36,10 @@
     public <fields>;
 }
 
+-keep public class com.chartboost.heliumsdk.domain.AdData {
+    public *;
+}
+
 -keep public class com.chartboost.heliumsdk.domain.Ad$AdType {}
 -keep public class com.chartboost.heliumsdk.domain.Ad$State {}
 


### PR DESCRIPTION
https://chartboost.atlassian.net/browse/HB-3812

New proguard rule:

```
-keep public class com.chartboost.heliumsdk.domain.AdData {
    public *;
}
```

Sister PR: https://github.com/ChartBoost/unity-helium-sdk/pull/213