### PR TITLE
[HB-3874] Updating Unit Tests with C# & Unity Coding Conventions

### DIFF
--- a/Tests/Editor/JsonParseTests.cs
+++ b/Tests/Editor/JsonParseTests.cs
@@ -1,45 +1,41 @@
-using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.TestTools;
 using System.IO;
-
-/// <summary>
-/// This suite of tests is intended to directly validate the parsing of JSON
-/// (or alleged JSON) using whatever parser is provided by the SDK.
-///
-/// Today, the parser is `JsonTools.HeliumJSON` in the file `JsonTools.cs`.
-///
-/// The suite uses the JSON text files in the directory Tests/TestJSON
-/// which were borrowed from this Github repository: https://github.com/nst/JSONTestSuite.
-/// Each file is prepended with single character, meaning:
-///
-/// i => the parser is free to accept or reject the content
-/// y => the parser must accept the content
-/// n => the parser must reject the content
-///
-/// Since the parser being used by the SDK may or may not be a completely exhaustive
-/// implementation, there may also be files that are prepended with additional
-/// characters, meaning:
-///
-/// s => skipped because the parser is not implemented to deal with this content
-/// x => will be a KNOWN failure and someday we need to make it pass
-/// 
-/// </summary>
 
 namespace Helium
 {
+    /// <summary>
+    /// This suite of tests is intended to directly validate the parsing of JSON
+    /// (or alleged JSON) using whatever parser is provided by the SDK.
+    ///
+    /// Today, the parser is `JsonTools.HeliumJSON` in the file `JsonTools.cs`.
+    ///
+    /// The suite uses the JSON text files in the directory Tests/TestJSON
+    /// which were borrowed from this Github repository: https://github.com/nst/JSONTestSuite.
+    /// Each file is prepended with single character, meaning:
+    ///
+    /// i => the parser is free to accept or reject the content
+    /// y => the parser must accept the content
+    /// n => the parser must reject the content
+    ///
+    /// Since the parser being used by the SDK may or may not be a completely exhaustive
+    /// implementation, there may also be files that are prepended with additional
+    /// characters, meaning:
+    ///
+    /// s => skipped because the parser is not implemented to deal with this content
+    /// x => will be a KNOWN failure and someday we need to make it pass
+    /// 
+    /// </summary>
     public class JsonParseTests
     {
-        enum Acceptance
+        private enum Acceptance
         {
             Optional,
             Accept,
             Reject
         }
 
-        enum Expectation
+        private enum Expectation
         {
             Pass,
             Skip,
@@ -63,82 +59,78 @@ namespace Helium
         }
 
         [Test]
-        public void ExhaustiveJSONTest()
+        public void ExhaustiveJsonTest()
         {
-            Debug.Log(string.Format("Running ExhaustiveJSONTest over a total of {0} files", _testFiles.Length));
-            int skippedCount = 0;
-            int expectedFails = 0;
+            Debug.Log($"Running ExhaustiveJSONTest over a total of {_testFiles.Length} files");
+            var skippedCount = 0;
+            var expectedFails = 0;
 
             foreach (string testFile in _testFiles)
             {
                 var fileName = Path.GetFileName(testFile);
                 
-                Expectation expectation = GetExpectation(fileName);
+                var expectation = GetExpectation(fileName);
                 if (expectation == Expectation.Skip)
                 {
                     skippedCount++;
                     continue;
                 }
 
-                Acceptance acceptance = GetAcceptance(fileName);
+                var acceptance = GetAcceptance(fileName);
 
                 // Read in the JSON
-                string path = testFile;
-                StreamReader reader = new StreamReader(path);
-                string json = reader.ReadToEnd();
+                var reader = new StreamReader(testFile);
+                var json = reader.ReadToEnd();
                 reader.Close();
 
-                object rawResult = HeliumJSON.Deserialize(json);
+                var rawResult = HeliumJSON.Deserialize(json);
                 switch (acceptance)
                 {
                     case Acceptance.Optional:
                         if (rawResult != null)
-                            Debug.Log(string.Format("optional acceptance was accepted: {0}", testFile));
+                            Debug.Log($"optional acceptance was accepted: {testFile}");
                         break;
                     case Acceptance.Accept:
                         if (testFile.Contains("lonely_null"))
                         {
                             if (expectation == Expectation.KnownFailure)
                             {
-                                Assert.NotNull(rawResult,
-                                    string.Format("known failure but will have passed: {0}", testFile));
+                                Assert.NotNull(rawResult, $"known failure but will have passed: {testFile}");
                                 expectedFails++;
                             }
                             else
-                                Assert.Null(rawResult, string.Format("expected to not fail: {0}", testFile));
+                                Assert.Null(rawResult, $"expected to not fail: {testFile}");
                         }
                         else
                         {
                             if (expectation == Expectation.KnownFailure)
                             {
-                                Assert.Null(rawResult,
-                                    string.Format("known failure but will have passed: {0}", testFile));
+                                Assert.Null(rawResult, $"known failure but will have passed: {testFile}");
                                 expectedFails++;
                             }
                             else
-                                Assert.NotNull(rawResult, string.Format("expected to not fail: {0}", testFile));
+                                Assert.NotNull(rawResult, $"expected to not fail: {testFile}");
                         }
 
                         break;
                     case Acceptance.Reject:
                         if (expectation == Expectation.KnownFailure)
                         {
-                            Assert.NotNull(rawResult,
-                                string.Format("reject known failure but will have passed: {0}", testFile));
+                            Assert.NotNull(rawResult, $"reject known failure but will have passed: {testFile}");
                             expectedFails++;
                         }
                         else
-                            Assert.Null(rawResult, string.Format("reject expected to not fail: {0}", testFile));
+                            Assert.Null(rawResult, $"reject expected to not fail: {testFile}");
 
                         break;
                 }
             }
 
-            Debug.LogWarning(string.Format("Skipped files in ExhaustiveJSONTest: {0}", skippedCount));
-            Debug.LogWarning(string.Format("Expected failed files in ExhaustiveJSONTest: {0}", expectedFails));
+            Debug.LogWarning($"Skipped files in ExhaustiveJSONTest: {skippedCount}");
+            Debug.LogWarning($"Expected failed files in ExhaustiveJSONTest: {expectedFails}");
         }
 
-        Acceptance GetAcceptance(string filename)
+        private static Acceptance GetAcceptance(string filename)
         {
             if (filename.StartsWith("i_") || filename.Contains("_i_"))
                 return Acceptance.Optional;
@@ -149,13 +141,11 @@ namespace Helium
             return Acceptance.Accept;
         }
 
-        Expectation GetExpectation(string filename)
+        private static Expectation GetExpectation(string filename)
         {
             if (filename.StartsWith("s_"))
                 return Expectation.Skip;
-            if (filename.StartsWith("x_"))
-                return Expectation.KnownFailure;
-            return Expectation.Pass;
+            return filename.StartsWith("x_") ? Expectation.KnownFailure : Expectation.Pass;
         }
     }
 }

--- a/Tests/Editor/ProcessEventWithErrorTests.cs
+++ b/Tests/Editor/ProcessEventWithErrorTests.cs
@@ -1,228 +1,223 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Helium
 {
     public class ProcessEventWithErrorTests
     {
-        HeliumEventProcessor eventProcessor;
-        Action<string> unexpectedSystemErrorDidOccurEvent;
-
-        [SetUp]
-        public void Setup()
-        {
-            eventProcessor = new HeliumEventProcessor();
-        }
+        private Action<string> _unexpectedSystemErrorDidOccurEvent;
 
         [TearDown]
         public void Teardown()
         {
-            if (unexpectedSystemErrorDidOccurEvent != null)
-                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= unexpectedSystemErrorDidOccurEvent;
+            if (_unexpectedSystemErrorDidOccurEvent != null)
+                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= _unexpectedSystemErrorDidOccurEvent;
         }
 
         [Test]
         public void NoAdFoundErrorCodeTest1()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoAdFound, error.errorCode);
                 Assert.AreEqual("An ad was not found.", error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"errorCode\": 0, \"errorDescription\": \"An ad was not found.\"}";
+            const string json = "{\"errorCode\": 0, \"errorDescription\": \"An ad was not found.\"}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
         public void NoAdFoundErrorCodeTest2()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoAdFound, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"errorCode\": 0}";
+            const string json = "{\"errorCode\": 0}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
         public void NoBidErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoBid, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"errorCode\": 1}";
+            const string json = "{\"errorCode\": 1}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
         public void NoNetworkErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoNetwork, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"errorCode\": 2}";
+            const string json = "{\"errorCode\": 2}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
         public void ServerErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.ServerError, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"errorCode\": 3}";
+            const string json = "{\"errorCode\": 3}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
         public void MinusOneErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) => { Assert.Null(error); };
+            void Event(HeliumError error)
+            {
+                Assert.Null(error);
+            }
 
             // The JSON string
-            string json = "{\"errorCode\": -1}";
+            const string json = "{\"errorCode\": -1}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
         public void UnknownErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.Unknown, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
-            string[] jsonsWithError = new string[]
+            var jsonsWithError = new[]
             {
                 "{\"errorCode\": 4}",
                 "{\"errorCode\": -1234}",
                 "{\"errorCode\": 1234}",
             };
 
-            foreach (string json in jsonsWithError)
+            foreach (var json in jsonsWithError)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithError(json, evt);
+                HeliumEventProcessor.ProcessEventWithError(json, Event);
             }
         }
 
         [Test]
         public void BlankStringTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with error", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<HeliumError> evt = (error) => { Assert.Fail(); };
+            void Event(HeliumError error)
+            {
+                Assert.Fail();
+            }
 
             // Process the event
-            eventProcessor.ProcessEventWithError("", evt);
+            HeliumEventProcessor.ProcessEventWithError("", Event);
         }
 
         [Test]
-        public void BlankJSONTest()
+        public void BlankJsonTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) => { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = _ => { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<HeliumError> evt = (error) =>
+            void Event(HeliumError error)
             {
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoAdFound, error.errorCode);
-            };
+            }
 
             // The JSON string
-            string json = "{}";
+            const string json = "{}";
 
             // Process the event
-            eventProcessor.ProcessEventWithError(json, evt);
+            HeliumEventProcessor.ProcessEventWithError(json, Event);
         }
 
         [Test]
-        public void NotJSONTest()
+        public void NotJsonTest()
         {
-            string[] notJSONStrings = new string[]
+            var notJsonStrings = new[]
             {
                 " ",
                 "x",
@@ -232,71 +227,80 @@ namespace Helium
                 "[\"errorCode\": \"3\"]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with error", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<HeliumError> evt = (error) => { Assert.Fail(); };
+            void Event(HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string notJSONString in notJSONStrings)
+            foreach (var notJsonString in notJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithError(notJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithError(notJsonString, Event);
             }
         }
 
         [Test]
-        public void UnacceptedJSONTest()
+        public void UnacceptedJsonTest()
         {
             // these are JSON but they aren't accepted due to the use case or implementation by design
-            string[] unacceptedJSONStrings = new string[]
+            var unacceptedJsonStrings = new[]
             {
                 "[{\"errorCode\": 1}]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with error", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<HeliumError> evt = (error) => { Assert.Fail(); };
+            void Event(HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string unacceptedJSONString in unacceptedJSONStrings)
+            foreach (var unacceptedJsonString in unacceptedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithError(unacceptedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithError(unacceptedJsonString, Event);
             }
         }
 
         [Test]
-        public void MalformedJSONTest()
+        public void MalformedJsonTest()
         {
-            string[] malformedJSONStrings = new string[]
+            var malformedJsonStrings = new[]
             {
                 "{[\"errorCode\": 2]}",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Malformed data received when processing event with error", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<HeliumError> evt = (error) => { Assert.Fail(); };
+            void Event(HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string malformedJSONString in malformedJSONStrings)
+            foreach (var malformedJsonString in malformedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithError(malformedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithError(malformedJsonString, Event);
             }
         }
     }

--- a/Tests/Editor/ProcessEventWithPlacementAndBidInfoTests.cs
+++ b/Tests/Editor/ProcessEventWithPlacementAndBidInfoTests.cs
@@ -1,147 +1,139 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Helium
 {
     public class ProcessEventWithPlacementAndBidInfo
     {
-        HeliumEventProcessor eventProcessor;
-        Action<string> unexpectedSystemErrorDidOccurEvent;
-
-        [SetUp]
-        public void Setup()
-        {
-            eventProcessor = new HeliumEventProcessor();
-        }
+        private Action<string> _unexpectedSystemErrorDidOccurEvent;
 
         [TearDown]
         public void Teardown()
         {
-            if (unexpectedSystemErrorDidOccurEvent != null)
-                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= unexpectedSystemErrorDidOccurEvent;
+            if (_unexpectedSystemErrorDidOccurEvent != null)
+                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= _unexpectedSystemErrorDidOccurEvent;
         }
 
         [Test]
-        public void TypicalJSONTest1()
+        public void TypicalJsonTest1()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) => { Assert.Fail(message); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = Assert.Fail;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) =>
+            void Event(string placementName, HeliumBidInfo bidInfo)
             {
                 StringAssert.IsMatch("TypicalJSONTest1", placementName);
                 StringAssert.IsMatch("abcdefg", bidInfo.AuctionId);
                 Assert.AreEqual(2.99, bidInfo.Price);
                 StringAssert.IsMatch("chair", bidInfo.Seat);
                 StringAssert.IsMatch("TypicalJSONTest1", bidInfo.PartnerPlacementName);
-            };
+            }
 
             // The JSON string
-            string json =
-                "{\"placementName\": \"TypicalJSONTest1\", \"info\": {\"auction-id\": \"abcdefg\", \"price\": 2.99, \"seat\": \"chair\", \"placementName\": \"TypicalJSONTest1\"}}";
+            const string json = "{\"placementName\": \"TypicalJSONTest1\", \"info\": {\"auction-id\": \"abcdefg\", \"price\": 2.99, \"seat\": \"chair\", \"placementName\": \"TypicalJSONTest1\"}}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndBidInfo(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(json, Event);
         }
 
         [Test]
-        public void TypicalJSONTest2()
+        public void TypicalJsonTest2()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) => { Assert.Fail(message); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = Assert.Fail;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) =>
+            void Event(string placementName, HeliumBidInfo bidInfo)
             {
                 StringAssert.IsMatch("TypicalJSONTest2", placementName);
                 StringAssert.IsMatch("1234567", bidInfo.AuctionId);
                 Assert.AreEqual(33.67, bidInfo.Price);
                 Assert.Null(bidInfo.Seat);
                 Assert.Null(bidInfo.PartnerPlacementName);
-            };
+            }
 
             // The JSON string
-            string json =
-                "{\"placementName\": \"TypicalJSONTest2\", \"info\": {\"auction-id\": \"1234567\", \"price\": 33.67 }}";
+            const string json = "{\"placementName\": \"TypicalJSONTest2\", \"info\": {\"auction-id\": \"1234567\", \"price\": 33.67 }}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndBidInfo(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(json, Event);
         }
 
         [Test]
-        public void TypicalJSONTest3()
+        public void TypicalJsonTest3()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) => { Assert.Fail(message); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = Assert.Fail;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) =>
+            void Event(string placementName, HeliumBidInfo bidInfo)
             {
                 StringAssert.IsMatch("TypicalJSONTest3", placementName);
                 StringAssert.IsMatch("𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢", bidInfo.AuctionId);
                 Assert.AreEqual(91.56, bidInfo.Price);
                 Assert.Null(bidInfo.Seat);
                 Assert.Null(bidInfo.PartnerPlacementName);
-            };
+            }
 
             // The JSON string
-            string json =
-                "{\"placementName\": \"TypicalJSONTest3\", \"info\": {\"auction-id\": \"𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢\", \"price\": \"91.56\" }}";
+            const string json = "{\"placementName\": \"TypicalJSONTest3\", \"info\": {\"auction-id\": \"𝘈Ḇ𝖢𝕯٤ḞԍНǏ𝙅ƘԸⲘ𝙉০Ρ𝗤Ɍ𝓢\", \"price\": \"91.56\" }}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndBidInfo(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(json, Event);
         }
 
         [Test]
         public void BlankStringTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.IsMatch("Non JSON data received when processing event with placement and bid info: ",
                     message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) => { Assert.Fail(); };
+            void Event(string placementName, HeliumBidInfo bidInfo)
+            {
+                Assert.Fail();
+            }
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndBidInfo("", evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo("", Event);
         }
 
         [Test]
-        public void BlankJSONTest()
+        public void BlankJsonTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.IsMatch("Placement name not provided at root of: \\{}", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) => { Assert.Fail(); };
+            void Event(string placementName, HeliumBidInfo bidInfo)
+            {
+                Assert.Fail();
+            }
 
             // The JSON string
-            string json = "{}";
+            const string json = "{}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndBidInfo(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(json, Event);
         }
 
         [Test]
-        public void NotJSONTest()
+        public void NotJsonTest()
         {
-            string[] notJSONStrings = new string[]
+            var notJsonStrings = new[]
             {
                 " ",
                 "x",
@@ -151,74 +143,80 @@ namespace Helium
                 "[\"placementName\": \"NotJSONTest\"]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
-                StringAssert.StartsWith("Non JSON data received when processing event with placement and bid info",
-                    message);
+                StringAssert.StartsWith("Non JSON data received when processing event with placement and bid info", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) => { Assert.Fail(); };
+            void Event(string placementName, HeliumBidInfo bidInfo)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string notJSONString in notJSONStrings)
+            foreach (var notJsonString in notJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndBidInfo(notJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(notJsonString, Event);
             }
         }
 
         [Test]
-        public void UnacceptedJSONTest()
+        public void UnacceptedJsonTest()
         {
             // these are JSON but they aren't accepted due to the use case or implementation by design
-            string[] unacceptedJSONStrings = new string[]
+            var unacceptedJsonStrings = new[]
             {
                 "[{\"placementName\": \"NotJSONTest\"}]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
-                StringAssert.StartsWith("Non JSON data received when processing event with placement and bid info",
-                    message);
+                StringAssert.StartsWith("Non JSON data received when processing event with placement and bid info", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) => { Assert.Fail(); };
+            void Event(string placementName, HeliumBidInfo bidInfo)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string unacceptedJSONString in unacceptedJSONStrings)
+            foreach (var unacceptedJsonString in unacceptedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndBidInfo(unacceptedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(unacceptedJsonString, Event);
             }
         }
 
         [Test]
-        public void MalformedJSONTest()
+        public void MalformedJsonTest()
         {
-            string[] malformedJSONStrings = new string[]
+            var malformedJsonStrings = new[]
             {
                 "{[\"placementName\": \"NotJSONTest\"]}",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
-                StringAssert.StartsWith("Malformed data received when processing event with placement and bid info",
-                    message);
+                StringAssert.StartsWith("Malformed data received when processing event with placement and bid info", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) => { Assert.Fail(); };
+            void Event(string placementName, HeliumBidInfo bidInfo)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string malformedJSONString in malformedJSONStrings)
+            foreach (var malformedJsonString in malformedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndBidInfo(malformedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(malformedJsonString, Event);
             }
         }
 
@@ -226,26 +224,29 @@ namespace Helium
         public void NoPlacementNameTest()
         {
             // these are JSON but they aren't accepted due to the use case
-            string[] unacceptedJSONStrings = new string[]
+            var unacceptedJsonStrings = new[]
             {
                 "{\"foo\": \"bar\"}",
                 "{\"info\": {\"auction-id\": \"abcdefg\", \"price\": 2.99, \"seat\": \"chair\", \"placementName\": \"ProcessEventWithPlacementAndBidInfoTest\"}}",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Placement name not provided at root of", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumBidInfo> evt = (placementName, bidInfo) => { Assert.Fail(); };
+            void Event(string placementName, HeliumBidInfo bidInfo)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string unacceptedJSONString in unacceptedJSONStrings)
+            foreach (var unacceptedJsonString in unacceptedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndBidInfo(unacceptedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndBidInfo(unacceptedJsonString, Event);
             }
         }
     }

--- a/Tests/Editor/ProcessEventWithPlacementAndErrorTests.cs
+++ b/Tests/Editor/ProcessEventWithPlacementAndErrorTests.cs
@@ -1,194 +1,182 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Helium
 {
     public class ProcessEventWithPlacementAndErrorTests
     {
-        HeliumEventProcessor eventProcessor;
-        Action<string> unexpectedSystemErrorDidOccurEvent;
-
-        [SetUp]
-        public void Setup()
-        {
-            eventProcessor = new HeliumEventProcessor();
-        }
+        private Action<string> _unexpectedSystemErrorDidOccurEvent;
 
         [TearDown]
         public void Teardown()
         {
-            if (unexpectedSystemErrorDidOccurEvent != null)
-                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= unexpectedSystemErrorDidOccurEvent;
+            if (_unexpectedSystemErrorDidOccurEvent != null)
+                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= _unexpectedSystemErrorDidOccurEvent;
         }
 
         [Test]
         public void NoAdFoundErrorCodeTest1()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("NoAdFoundErrorCodeTest1", placementName);
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoAdFound, error.errorCode);
                 Assert.AreEqual("An ad was not found.", error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json =
-                "{\"placementName\": \"NoAdFoundErrorCodeTest1\", \"errorCode\": 0, \"errorDescription\": \"An ad was not found.\"}";
+            const string json = "{\"placementName\": \"NoAdFoundErrorCodeTest1\", \"errorCode\": 0, \"errorDescription\": \"An ad was not found.\"}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
         public void NoAdFoundErrorCodeTest2()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("NoAdFoundErrorCodeTest2", placementName);
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoAdFound, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"placementName\": \"NoAdFoundErrorCodeTest2\", \"errorCode\": 0}";
+            const string json = "{\"placementName\": \"NoAdFoundErrorCodeTest2\", \"errorCode\": 0}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
         public void NoBidErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("NoBidErrorCodeTest", placementName);
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoBid, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"placementName\": \"NoBidErrorCodeTest\", \"errorCode\": 1}";
+            const string json = "{\"placementName\": \"NoBidErrorCodeTest\", \"errorCode\": 1}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
         public void NoNetworkErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("NoNetworkErrorCodeTest", placementName);
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.NoNetwork, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"placementName\": \"NoNetworkErrorCodeTest\", \"errorCode\": 2}";
+            const string json = "{\"placementName\": \"NoNetworkErrorCodeTest\", \"errorCode\": 2}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
         public void ServerErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("ServerErrorCodeTest", placementName);
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.ServerError, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
             // The JSON string
-            string json = "{\"placementName\": \"ServerErrorCodeTest\", \"errorCode\": 3}";
+            const string json = "{\"placementName\": \"ServerErrorCodeTest\", \"errorCode\": 3}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
         public void MinusOneErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("MinusOneErrorCodeTest", placementName);
                 Assert.Null(error);
-            };
+            }
 
             // The JSON string
-            string json = "{\"placementName\": \"MinusOneErrorCodeTest\", \"errorCode\": -1}";
+            const string json = "{\"placementName\": \"MinusOneErrorCodeTest\", \"errorCode\": -1}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
         public void UnknownErrorCodeTest()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) =>
+            void Event(string placementName, HeliumError error)
             {
                 Assert.AreEqual("UnknownErrorCodeTest", placementName);
                 Assert.NotNull(error);
                 Assert.AreEqual(HeliumErrorCode.Unknown, error.errorCode);
                 Assert.Null(error.errorDescription);
-            };
+            }
 
-            string[] jsonsWithError = new string[]
+            var jsonsWithError = new[]
             {
                 "{\"placementName\": \"UnknownErrorCodeTest\", \"errorCode\": 4}",
                 "{\"placementName\": \"UnknownErrorCodeTest\", \"errorCode\": -1234}",
                 "{\"placementName\": \"UnknownErrorCodeTest\", \"errorCode\": 1234}",
             };
 
-            foreach (string json in jsonsWithError)
+            foreach (var json in jsonsWithError)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
             }
         }
 
@@ -196,71 +184,80 @@ namespace Helium
         public void NoPlacementNameTest()
         {
             // these are JSON but they aren't accepted due to the use case
-            string[] unacceptedJSONStrings = new string[]
+            var unacceptedJsonStrings = new[]
             {
                 "{\"foo\": \"bar\"}",
                 "{\"error\": 4}",
                 "{\"error\": \"1\"}",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Placement name not provided at root of", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) => { Assert.Fail(); };
+            void Event(string placementName, HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string unacceptedJSONString in unacceptedJSONStrings)
+            foreach (var unacceptedJsonString in unacceptedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndError(unacceptedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndError(unacceptedJsonString, Event);
             }
         }
 
         [Test]
         public void BlankStringTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with placement", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) => { Assert.Fail(); };
+            void Event(string placementName, HeliumError error)
+            {
+                Assert.Fail();
+            }
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError("", evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError("", Event);
         }
 
         [Test]
-        public void BlankJSONTest()
+        public void BlankJsonTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Placement name not provided at root of", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) => { Assert.Fail(); };
+            void Event(string placementName, HeliumError error)
+            {
+                Assert.Fail();
+            }
 
             // The JSON string
-            string json = "{}";
+            const string json = "{}";
 
             // Process the event
-            eventProcessor.ProcessEventWithPlacementAndError(json, evt);
+            HeliumEventProcessor.ProcessEventWithPlacementAndError(json, Event);
         }
 
         [Test]
-        public void NotJSONTest()
+        public void NotJsonTest()
         {
-            string[] notJSONStrings = new string[]
+            var notJsonStrings = new[]
             {
                 " ",
                 "x",
@@ -271,73 +268,82 @@ namespace Helium
                 "[\"placementName\": \"NotJSONTest\"]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with placement", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) => { Assert.Fail(); };
+            void Event(string placementName, HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string notJSONString in notJSONStrings)
+            foreach (var notJsonString in notJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndError(notJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndError(notJsonString, Event);
             }
         }
 
         [Test]
-        public void UnacceptedJSONTest()
+        public void UnacceptedJsonTest()
         {
             // these are JSON but they aren't accepted due to the use case or implementation by design
-            string[] unacceptedJSONStrings = new string[]
+            var unacceptedJsonStrings = new[]
             {
                 "[{\"errorCode\": 1}]",
                 "[{\"placementName\": \"UnacceptedJSONTest\"}]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with placement", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) => { Assert.Fail(); };
+            void Event(string placementName, HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string unacceptedJSONString in unacceptedJSONStrings)
+            foreach (var unacceptedJsonString in unacceptedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndError(unacceptedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndError(unacceptedJsonString, Event);
             }
         }
 
         [Test]
-        public void MalformedJSONTest()
+        public void MalformedJsonTest()
         {
-            string[] malformedJSONStrings = new string[]
+            var malformedJsonStrings = new[]
             {
                 "{[\"errorCode\": 2]}",
                 "{[\"placementName\": \"MalformedJSONTest\"]}",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Malformed data received when processing event with placement", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string, HeliumError> evt = (placementName, error) => { Assert.Fail(); };
+            void Event(string placementName, HeliumError error)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string malformedJSONString in malformedJSONStrings)
+            foreach (var malformedJsonString in malformedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithPlacementAndError(malformedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithPlacementAndError(malformedJsonString, Event);
             }
         }
     }

--- a/Tests/Editor/ProcessEventWithRewardTests.cs
+++ b/Tests/Editor/ProcessEventWithRewardTests.cs
@@ -1,122 +1,126 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
-using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Helium
 {
     public class ProcessEventWithRewardTests
     {
-        HeliumEventProcessor eventProcessor;
-        Action<string> unexpectedSystemErrorDidOccurEvent;
-
-        [SetUp]
-        public void Setup()
-        {
-            eventProcessor = new HeliumEventProcessor();
-        }
+        private Action<string> _unexpectedSystemErrorDidOccurEvent;
 
         [TearDown]
         public void Teardown()
         {
-            if (unexpectedSystemErrorDidOccurEvent != null)
-                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= unexpectedSystemErrorDidOccurEvent;
+            if (_unexpectedSystemErrorDidOccurEvent != null)
+                HeliumEventProcessor.UnexpectedSystemErrorDidOccur -= _unexpectedSystemErrorDidOccurEvent;
         }
 
         [Test]
-        public void TypicalJSONTest1()
+        public void TypicalJsonTest1()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string> evt = (reward) => { StringAssert.IsMatch("500", reward); };
+            void Event(string reward)
+            {
+                StringAssert.IsMatch("500", reward);
+            }
 
             // The JSON string
-            string json = "{\"reward\": 500}";
+            const string json = "{\"reward\": 500}";
 
             // Process the event
-            eventProcessor.ProcessEventWithReward(json, evt);
+            HeliumEventProcessor.ProcessEventWithReward(json, Event);
         }
 
         [Test]
-        public void TypicalJSONTest2()
+        public void TypicalJsonTest2()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string> evt = (reward) => { StringAssert.IsMatch("trophy:93282", reward); };
+            void Event(string reward)
+            {
+                StringAssert.IsMatch("trophy:93282", reward);
+            }
 
             // The JSON string
-            string json = "{\"reward\": \"trophy:93282\"}";
+            const string json = "{\"reward\": \"trophy:93282\"}";
 
             // Process the event
-            eventProcessor.ProcessEventWithReward(json, evt);
+            HeliumEventProcessor.ProcessEventWithReward(json, Event);
         }
 
         [Test]
-        public void TypicalJSONTest3()
+        public void TypicalJsonTest3()
         {
-            // Should NOT get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            // Should NOT get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = delegate { Assert.Fail(); };
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should get an expected system event
-            Action<string> evt = (reward) => { StringAssert.IsMatch("500", reward); };
+            void Event(string reward)
+            {
+                StringAssert.IsMatch("500", reward);
+            }
 
             // The JSON string
-            string json = "{\"reward\": \"500\"}";
+            const string json = "{\"reward\": \"500\"}";
 
             // Process the event
-            eventProcessor.ProcessEventWithReward(json, evt);
+            HeliumEventProcessor.ProcessEventWithReward(json, Event);
         }
 
         [Test]
         public void BlankStringTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with reward", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string> evt = (reward) => { Assert.Fail(); };
+            void Event(string reward)
+            {
+                Assert.Fail();
+            }
 
             // Process the event
-            eventProcessor.ProcessEventWithReward("", evt);
+            HeliumEventProcessor.ProcessEventWithReward("", Event);
         }
 
         [Test]
-        public void BlankJSONTest()
+        public void BlankJsonTest()
         {
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Reward object not included with JSON payload", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string> evt = (reward) => { Assert.Fail(); };
+            void Event(string reward)
+            {
+                Assert.Fail();
+            }
 
             // The JSON string
-            string json = "{}";
+            const string json = "{}";
 
             // Process the event
-            eventProcessor.ProcessEventWithReward(json, evt);
+            HeliumEventProcessor.ProcessEventWithReward(json, Event);
         }
 
         [Test]
-        public void NotJSONTest()
+        public void NotJsonTest()
         {
-            string[] notJSONStrings = new string[]
+            var notJsonStrings = new[]
             {
                 " ",
                 "x",
@@ -126,71 +130,80 @@ namespace Helium
                 "[\"reward\": \"12345\"]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with reward", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string> evt = (reward) => { Assert.Fail(); };
+            void Event(string reward)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string notJSONString in notJSONStrings)
+            foreach (var notJsonString in notJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithReward(notJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithReward(notJsonString, Event);
             }
         }
 
         [Test]
-        public void UnacceptedJSONTest()
+        public void UnacceptedJsonTest()
         {
             // these are JSON but they aren't accepted due to the use case or implementation by design
-            string[] unacceptedJSONStrings = new string[]
+            var unacceptedJsonStrings = new[]
             {
                 "[{\"reward\": \"trophy:555\"}]",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Non JSON data received when processing event with reward", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string> evt = (reward) => { Assert.Fail(); };
+            void Event(string reward)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string unacceptedJSONString in unacceptedJSONStrings)
+            foreach (var unacceptedJsonString in unacceptedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithReward(unacceptedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithReward(unacceptedJsonString, Event);
             }
         }
 
         [Test]
-        public void MalformedJSONTest()
+        public void MalformedJsonTest()
         {
-            string[] malformedJSONStrings = new string[]
+            var malformedJsonStrings = new[]
             {
                 "{[\"reward\": 10]}",
             };
 
-            // Should get an unexepected system error event
-            unexpectedSystemErrorDidOccurEvent = (message) =>
+            // Should get an unexpected system error event
+            _unexpectedSystemErrorDidOccurEvent = (message) =>
             {
                 StringAssert.StartsWith("Malformed data received when processing event with reward", message);
             };
-            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += unexpectedSystemErrorDidOccurEvent;
+            HeliumEventProcessor.UnexpectedSystemErrorDidOccur += _unexpectedSystemErrorDidOccurEvent;
 
             // Should NOT get an expected system event
-            Action<string> evt = (reward) => { Assert.Fail(); };
+            void Event(string reward)
+            {
+                Assert.Fail();
+            }
 
-            foreach (string malformedJSONString in malformedJSONStrings)
+            foreach (var malformedJsonString in malformedJsonStrings)
             {
                 // Process the event
-                eventProcessor.ProcessEventWithReward(malformedJSONString, evt);
+                HeliumEventProcessor.ProcessEventWithReward(malformedJsonString, Event);
             }
         }
     }


### PR DESCRIPTION
## Descriptions
Since Unit tests were added after the C# coding conventions were updated on the codebase, some compilation errors and improvements could still be done to this files. This PR is just to make sure that the Unit test remain consistent with the rest of the codebase. It works! AFAIK, some of this Unit tests might be entirely removed after we decide to go forward with AndroidJavaProxy & MonoPInvoke. 


## Changes
- Fixing Compilation Errors from changes to HeliumEventProcessor
- Removing warnings
- Improving code readability and consistency
- Replacing string formatting with string interpolation
- Removing unused namespaces