### PR TITLE
[HB-3869] _heliumSetUserIdentifer & _heliumGetUserIdentifer typo on iOS Bridge

### DIFF
--- a/Runtime/HeliumExternal.cs
+++ b/Runtime/HeliumExternal.cs
@@ -55,11 +55,11 @@ namespace Helium
 		
 		// todo - https://chartboost.atlassian.net/browse/HB-3869 this has a typo on it, needs to be corrected.
 		[DllImport("__Internal")]
-		private static extern void _heliumSetUserIdentifer(string userIdentifier);
+		private static extern void _heliumSetUserIdentifier(string userIdentifier);
 		
 		// todo - https://chartboost.atlassian.net/browse/HB-3869 this has a typo on it, needs to be corrected.
 		[DllImport("__Internal")]
-		private static extern string _heliumGetUserIdentifer();
+		private static extern string _heliumGetUserIdentifier();
 
 		/// Initializes the Helium plugin.
 		/// This must be called before using any other Helium features.
@@ -113,14 +113,14 @@ namespace Helium
 		{
 			Log($"Helium(iOS): SetUserIdentifier {userIdentifier}");
 			if (!Application.isEditor)
-				_heliumSetUserIdentifer(userIdentifier);
+				_heliumSetUserIdentifier(userIdentifier);
 		}
 
 		public static string GetUserIdentifier()
 		{
 			Log("Helium(iOS): GetUserIdentifier");
 			if (!Application.isEditor)
-				return _heliumGetUserIdentifer();
+				return _heliumGetUserIdentifier();
 			else
 				return null;
 		}

--- a/Runtime/Plugins/iOS/HeliumBinding.m
+++ b/Runtime/Plugins/iOS/HeliumBinding.m
@@ -49,12 +49,12 @@ void _heliumSetCCPAConsent(BOOL hasGivenConsent)
     [[HeliumSdkManager sharedManager] setCCPAConsent:hasGivenConsent];
 }
 
-void _heliumSetUserIdentifer(const char * userIdentifier)
+void _heliumSetUserIdentifier(const char * userIdentifier)
 {
     [[HeliumSdkManager sharedManager] setUserIdentifier:GetStringParam(userIdentifier)];
 }
 
-char * _heliumGetUserIdentifer()
+char * _heliumGetUserIdentifier()
 {
     return ConvertNSStringToCString([[HeliumSdkManager sharedManager] getUserIdentifier]);
 }


### PR DESCRIPTION
## Description
The _heliumSetUserIdentifer & _heliumGetUserIdentifer had a small typo on the codebase. It has been corrected.

## Changes
- Fixing Typo in HeliumBiding.m
- Fixing Typo in HeliumExternal.cs