### PR TITLE
[HB-3821] Enabling Nightly Checks

### DIFF
--- a/.github/workflows/helium-unity.yml
+++ b/.github/workflows/helium-unity.yml
@@ -1,4 +1,4 @@
-name: ci-tests
+name: Helium Unity SDK
 
 on:
   push:
@@ -8,6 +8,10 @@ on:
     branches:
       - 'develop'
       - 'main'
+  schedule:
+    # Scheduled to run Monday - Friday at 9AM UTC which is 2AM PST.
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '0 9 * * 1-5'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
# Description

Check stuff nightly... it's pretty straight forward. It will run at 2AM from Monday - Friday. Unlike the iOS & Android counterparts, we do not have a very robust environment, so just making sure we can run our existing CI without issues every night should be more than enough. It should take 3-5 min to complete when Unity is already installed in self-hosted runner.

# Changes
* Enabled Nightly Builds
* Renamed CI File and Workflow Name.