### PR TITLE
[HB-4285] Upgrade Unity Version to 2020.3.37f1

### DIFF
--- a/.github/workflows/helium-unity.yml
+++ b/.github/workflows/helium-unity.yml
@@ -23,8 +23,8 @@ on:
         required: false
         default: 'false'
 env:
-  UNITY_VERSION: 2020.3.27f1
-  UNITY_EXE_PATH: /Applications/Unity/Hub/Editor/2020.3.27f1/Unity.app/Contents/MacOS/Unity
+  UNITY_VERSION: 2020.3.37f1
+  UNITY_EXE_PATH: /Applications/Unity/Hub/Editor/2020.3.37f1/Unity.app/Contents/MacOS/Unity
   PROJECT_PATH: com.chartboost.helium.demo
 
 # Cancels any queued or in-progress runs for this branch.
@@ -54,7 +54,7 @@ jobs:
       timeout-minutes: 60
       with:
         unity-version: ${{ env.UNITY_VERSION }}
-        unity-version-changeset: e759542391ea
+        unity-version-changeset: 8c66806a0c04
         unity-modules:
           android
           ios

--- a/com.chartboost.helium.demo/Packages/manifest.json
+++ b/com.chartboost.helium.demo/Packages/manifest.json
@@ -2,10 +2,10 @@
   "dependencies": {
     "com.chartboost.helium": "file:../../com.chartboost.helium",
     "com.google.external-dependency-manager": "file:../GooglePackages/com.google.external-dependency-manager-1.2.171.tgz",
-    "com.unity.collab-proxy": "1.15.7",
+    "com.unity.collab-proxy": "1.17.0",
     "com.unity.ide.rider": "3.0.15",
-    "com.unity.ide.visualstudio": "2.0.12",
-    "com.unity.ide.vscode": "1.2.4",
+    "com.unity.ide.visualstudio": "2.0.16",
+    "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.1.31",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",

--- a/com.chartboost.helium.demo/Packages/packages-lock.json
+++ b/com.chartboost.helium.demo/Packages/packages-lock.json
@@ -15,11 +15,10 @@
       "dependencies": {}
     },
     "com.unity.collab-proxy": {
-      "version": "1.15.7",
+      "version": "1.17.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.0",
         "com.unity.services.core": "1.0.1"
       },
       "url": "https://packages.unity.com"
@@ -41,7 +40,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.12",
+      "version": "2.0.16",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -50,7 +49,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.ide.vscode": {
-      "version": "1.2.4",
+      "version": "1.2.5",
       "depth": 0,
       "source": "registry",
       "dependencies": {},

--- a/com.chartboost.helium.demo/ProjectSettings/ProjectVersion.txt
+++ b/com.chartboost.helium.demo/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2020.3.27f1
-m_EditorVersionWithRevision: 2020.3.27f1 (e759542391ea)
+m_EditorVersion: 2020.3.37f1
+m_EditorVersionWithRevision: 2020.3.37f1 (8c66806a0c04)


### PR DESCRIPTION
# Description

This upgrade is mostly targeted for the fixes it includes towards XCode project/workspace generation. This is the latest LTS release as of August 2, 2022.