### PR TITLE
[HB-4860] Removing FAN & APS Explicit Native Dependencies.

### DIFF
--- a/com.chartboost.helium.demo/Assets/Samples/Helium SDK/3.3.0/Amazon/Editor/Optional-HeliumApsDependencies.xml
+++ b/com.chartboost.helium.demo/Assets/Samples/Helium SDK/3.3.0/Amazon/Editor/Optional-HeliumApsDependencies.xml
@@ -18,10 +18,5 @@
                 <source>https://github.com/CocoaPods/Specs</source>
             </sources>
         </iosPod>
-        <iosPod name="AmazonPublisherServicesSDK" version="~> 4.4" addToAllTargets="true">
-            <sources>
-                <source>https://github.com/CocoaPods/Specs</source>
-            </sources>
-        </iosPod>
     </iosPods>
 </dependencies>

--- a/com.chartboost.helium.demo/Assets/Samples/Helium SDK/3.3.0/Facebook/Editor/Optional-HeliumFacebookDependencies.xml
+++ b/com.chartboost.helium.demo/Assets/Samples/Helium SDK/3.3.0/Facebook/Editor/Optional-HeliumFacebookDependencies.xml
@@ -14,6 +14,5 @@
                 <source>https://github.com/CocoaPods/Specs</source>
             </sources>
         </iosPod>
-        <iosPod name="FBAudienceNetwork" version="~> 6.9.0" />
     </iosPods>
 </dependencies>

--- a/com.chartboost.helium/Samples~/Amazon/Editor/Optional-HeliumApsDependencies.xml
+++ b/com.chartboost.helium/Samples~/Amazon/Editor/Optional-HeliumApsDependencies.xml
@@ -18,10 +18,5 @@
                 <source>https://github.com/CocoaPods/Specs</source>
             </sources>
         </iosPod>
-        <iosPod name="AmazonPublisherServicesSDK" version="~> 4.4" addToAllTargets="true">
-            <sources>
-                <source>https://github.com/CocoaPods/Specs</source>
-            </sources>
-        </iosPod>
     </iosPods>
 </dependencies>

--- a/com.chartboost.helium/Samples~/Facebook/Editor/Optional-HeliumFacebookDependencies.xml
+++ b/com.chartboost.helium/Samples~/Facebook/Editor/Optional-HeliumFacebookDependencies.xml
@@ -14,6 +14,5 @@
                 <source>https://github.com/CocoaPods/Specs</source>
             </sources>
         </iosPod>
-        <iosPod name="FBAudienceNetwork" version="~> 6.9.0" />
     </iosPods>
 </dependencies>


### PR DESCRIPTION
# Description

FAN & APS were explicitly stating their native SDKs version in the Dependency.xml file. This meant that it would overwrite and collide with the Helium Adapters stated dependency for such SDKs. By removing this 2 references FAN & APS are now following the same format as all other Ad Adapter dependency files.

This was a race condition that was not identified internally because we increased the minimum deployment target which skipped the issue altogether. 

By adding this changes, we effectively simplify the maintenance process for iOS dependencies in Unity.