### PR TITLE
[HB-5572] iOS Banners Crashing on Removal

### DIFF
--- a/com.chartboost.mediation/Runtime/Banner/ChartboostMediationBannerIOS.cs
+++ b/com.chartboost.mediation/Runtime/Banner/ChartboostMediationBannerIOS.cs
@@ -74,7 +74,7 @@ namespace Chartboost.Banner
         [DllImport("__Internal")]
         private static extern void _chartboostMediationBannerClearLoaded(IntPtr uniqueID);
         [DllImport("__Internal")]
-        private static extern bool _chartboostMediationBannerRemove(IntPtr uniqueID);
+        private static extern void _chartboostMediationBannerRemove(IntPtr uniqueID);
         [DllImport("__Internal")]
         private static extern bool _chartboostMediationBannerSetVisibility(IntPtr uniqueID, bool isVisible);
         [DllImport("__Internal")]


### PR DESCRIPTION
# Description

When refactoring banners, this should have been marked as void not bool. 