### PR TITLE
[HB-5746] Adding New Networks Through CI/CD API Should Report Added Networks

### DIFF
--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindow.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindow.cs
@@ -116,7 +116,7 @@ namespace Chartboost.Editor.Adapters
                 scaleMode = ScaleMode.ScaleToFit
             };
 
-            var upgradeButton = new Button(() => UpgradeSelectionsToLatest());
+            var upgradeButton = new Button(() => UpgradePlatformToLatest(Platform.Android | Platform.IOS));
             upgradeButton.name = "upgrade-button";
             upgradeButton.tooltip = "Upgrade all adapter selections to their latest version!";
             upgradeButton.Add(upgradeImage);

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindow.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindow.cs
@@ -19,6 +19,7 @@ namespace Chartboost.Editor.Adapters
         private static string MediationSelection { get; set; }
        
         private static Button _saveButton;
+        private static Button _warningButton;
 
         public static AdaptersWindow Instance {
             get
@@ -70,15 +71,14 @@ namespace Chartboost.Editor.Adapters
             
             var package = Utilities.FindPackage(Constants.ChartboostMediationPackageName);
             
-            var warningFixButton = new Button();
-            warningFixButton.name = "warning-button";
-            warningFixButton.Add(logo);
-            warningFixButton.clicked += FixWarning;
+            _warningButton = new Button(() => CheckChartboostMediationVersion());
+            _warningButton.name = "warning-button";
+            _warningButton.Add(logo);
             
             if (string.IsNullOrEmpty(MediationSelection) || !Constants.PathToMainDependency.FileExist())
             {
-                warningFixButton.tooltip = $"Dependencies for Chartboost Mediation {package.version} have not been found. Press to add.";
-                root.Add(warningFixButton);
+                _warningButton.tooltip = $"Dependencies for Chartboost Mediation {package.version} have not been found. Press to add.";
+                root.Add(_warningButton);
                 return;
             }
             
@@ -87,16 +87,8 @@ namespace Chartboost.Editor.Adapters
             
             if (version != packageVersion)
             {
-                warningFixButton.tooltip = $"Your selected dependencies for Chartboost Mediation {version} do not match your current package version {packageVersion}. Press to fix.";
-                root.Add(warningFixButton);
-            }
-
-            void FixWarning()
-            {
-                warningFixButton.clicked -= FixWarning;
-                warningFixButton.RemoveFromHierarchy();
-                MediationSelection = package.version;
-                GenerateChartboostMediationDependency();
+                _warningButton.tooltip = $"Your selected dependencies for Chartboost Mediation {version} do not match your current package version {packageVersion}. Press to fix.";
+                root.Add(_warningButton);
             }
         }
 

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowSerialization.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowSerialization.cs
@@ -57,7 +57,7 @@ namespace Chartboost.Editor.Adapters
             UpdateSavedVersions();
         }
 
-        public static void GenerateDependenciesFromSelections()
+        private static void GenerateDependenciesFromSelections()
         {
             if (!Constants.PathToAdapterTemplate.FileExist())
             {
@@ -213,7 +213,7 @@ namespace Chartboost.Editor.Adapters
             AssetDatabase.Refresh();
         }
 
-        public static void GenerateChartboostMediationDependency()
+        private static void GenerateChartboostMediationDependency()
         {
             if (!Constants.PathToMainTemplate.FileExist())
             {

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
@@ -10,36 +10,6 @@ namespace Chartboost.Editor.Adapters
 {
     public partial class AdaptersWindow
     {
-        private static void Refresh(bool ignore = true)
-        {
-            if (!Application.isBatchMode)
-                Instance.rootVisualElement.Clear();
-            AdapterDataSource.Update();
-            Initialize();
-            if (!Application.isBatchMode|| !ignore)
-                EditorUtility.DisplayDialog("Chartboost Mediation", "Adapter update completed.", "ok");
-        }
-        
-        private static bool CheckForChanges()
-        {
-            var same = new DictionaryComparer<string, AdapterSelection>(new SelectedVersionsComparer()).Equals(UserSelectedVersions, SavedVersions);
-
-            if (Application.isBatchMode)
-                return same;
-
-            var root = Instance.rootVisualElement;
-            switch (same)
-            {
-                case false when _saveButton != null && !root.Contains(_saveButton):
-                    root.Add(_saveButton);
-                    break;
-                case true:
-                    _saveButton?.RemoveFromHierarchy();
-                    break;
-            }
-            return same;
-        }
-        
         public static List<AdapterSelection> AddNewNetworks(Platform platform, Func<string, Dictionary<string, AdapterSelection>, bool> condition)
         {
             var newNetworks = new List<AdapterSelection>();
@@ -125,32 +95,24 @@ namespace Chartboost.Editor.Adapters
             NoChangesDialog();
             return selectionChanges;
         }
-
-        private static bool WarningDialog()
+        
+        public static bool CheckChartboostMediationVersion()
         {
-            if (Application.isBatchMode)
-                return true;
+            if (!Application.isBatchMode && _warningButton != null)
+                _warningButton.RemoveFromHierarchy();
+            var package = Utilities.FindPackage(Constants.ChartboostMediationPackageName);
+
+            var version = new Version(MediationSelection);
+            var packageVersion = new Version(package.version);
+
+            if (!string.IsNullOrEmpty(MediationSelection) && Constants.PathToMainDependency.FileExist() &&
+                version == packageVersion) return false;
             
-            var cancel = false;
-            if (!Application.isBatchMode) { 
-                cancel = EditorUtility.DisplayDialog(
-                    "Chartboost Mediation", 
-                    "Doing this will update all of your selected adapters to their latest version, do you wish to continue?", "Yes", "No");
-            }
-            return cancel;
+            MediationSelection = package.version;
+            GenerateChartboostMediationDependency();
+            return true;
         }
-
-        private static void NoChangesDialog()
-        {
-            if (CheckForChanges() && !Application.isBatchMode)
-            {
-                EditorUtility.DisplayDialog(
-                    "Chartboost Mediation", 
-                    "No adapters updated, everything is already up to date!\n\n Do you think this is incorrect? Try using the refresh button.",
-                    "Ok");
-            }
-        }
-
+        
         private static void UpdateSelection(IReadOnlyList<string> versions, List<AdapterChange> selectionChanges,  string id, string startValue, Platform platform)
         {
             if (startValue.Equals(Constants.Unselected))
@@ -181,6 +143,61 @@ namespace Chartboost.Editor.Adapters
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(platform), platform, null);
+            }
+        }
+        
+        private static void Refresh(bool ignore = true)
+        {
+            if (!Application.isBatchMode)
+                Instance.rootVisualElement.Clear();
+            AdapterDataSource.Update();
+            Initialize();
+            if (!Application.isBatchMode|| !ignore)
+                EditorUtility.DisplayDialog("Chartboost Mediation", "Adapter update completed.", "ok");
+        }
+        
+        private static bool CheckForChanges()
+        {
+            var same = new DictionaryComparer<string, AdapterSelection>(new SelectedVersionsComparer()).Equals(UserSelectedVersions, SavedVersions);
+
+            if (Application.isBatchMode)
+                return same;
+
+            var root = Instance.rootVisualElement;
+            switch (same)
+            {
+                case false when _saveButton != null && !root.Contains(_saveButton):
+                    root.Add(_saveButton);
+                    break;
+                case true:
+                    _saveButton?.RemoveFromHierarchy();
+                    break;
+            }
+            return same;
+        }
+
+        private static bool WarningDialog()
+        {
+            if (Application.isBatchMode)
+                return true;
+            
+            var cancel = false;
+            if (!Application.isBatchMode) { 
+                cancel = EditorUtility.DisplayDialog(
+                    "Chartboost Mediation", 
+                    "Doing this will update all of your selected adapters to their latest version, do you wish to continue?", "Yes", "No");
+            }
+            return cancel;
+        }
+
+        private static void NoChangesDialog()
+        {
+            if (CheckForChanges() && !Application.isBatchMode)
+            {
+                EditorUtility.DisplayDialog(
+                    "Chartboost Mediation", 
+                    "No adapters updated, everything is already up to date!\n\n Do you think this is incorrect? Try using the refresh button.",
+                    "Ok");
             }
         }
     }

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
@@ -21,7 +21,7 @@ namespace Chartboost.Editor.Adapters
                 EditorUtility.DisplayDialog("Chartboost Mediation", "Adapter update completed.", "ok");
         }
         
-        public static bool CheckForChanges()
+        private static bool CheckForChanges()
         {
             var same = new DictionaryComparer<string, AdapterSelection>(new SelectedVersionsComparer()).Equals(UserSelectedVersions, SavedVersions);
 
@@ -40,11 +40,8 @@ namespace Chartboost.Editor.Adapters
             }
             return same;
         }
-
-        public static List<AdapterSelection> AddNewAndroidNetworks(Func<string, Dictionary<string, AdapterSelection>, bool> condition) => AddNewNetworks(Platform.Android, condition);
-        public static List<AdapterSelection> AddNewIOSNetworks(Func<string, Dictionary<string, AdapterSelection>, bool> condition) => AddNewNetworks(Platform.IOS, condition);
-        public static List<AdapterSelection> AddAllNewNetworks(Func<string, Dictionary<string, AdapterSelection>, bool>  condition) => AddNewNetworks(Platform.Android | Platform.IOS, condition);
-        private static List<AdapterSelection> AddNewNetworks(Platform platform, Func<string, Dictionary<string, AdapterSelection>, bool> condition)
+        
+        public static List<AdapterSelection> AddNewNetworks(Platform platform, Func<string, Dictionary<string, AdapterSelection>, bool> condition)
         {
             var newNetworks = new List<AdapterSelection>();
 
@@ -94,11 +91,8 @@ namespace Chartboost.Editor.Adapters
             GenerateDependenciesFromSelections();
             return newNetworks;
         }
-
-        public static List<AdapterChange> UpgradeAndroidSelectionsToLatest() => UpgradePlatformToLatest(Platform.Android);
-        public static List<AdapterChange> UpgradeIOSSelectionsToLatest() => UpgradePlatformToLatest(Platform.IOS);
-        public static List<AdapterChange> UpgradeSelectionsToLatest() => UpgradePlatformToLatest(Platform.Android | Platform.IOS);
-        private static List<AdapterChange> UpgradePlatformToLatest(Platform platform)
+        
+        public static List<AdapterChange> UpgradePlatformToLatest(Platform platform)
         {
             var selectionChanges = new List<AdapterChange>();
             if (!WarningDialog())

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
@@ -55,9 +55,6 @@ namespace Chartboost.Editor.Adapters
                 UserSelectedVersions[id] = selection;
             }
             
-            var package = Utilities.FindPackage(Constants.ChartboostMediationPackageName);
-            MediationSelection = package.version;
-            GenerateChartboostMediationDependency();
             GenerateDependenciesFromSelections();
             return newNetworks;
         }

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
@@ -41,24 +41,23 @@ namespace Chartboost.Editor.Adapters
             return same;
         }
 
-        public static List<AdapterSelection> AddNewAndroidNetworks() => AddNewNetworks(Platform.Android);
-        public static List<AdapterSelection> AddNewIOSNetworks() => AddNewNetworks(Platform.IOS);
-        public static List<AdapterSelection> AddAllNewNetworks() => AddNewNetworks(Platform.Android | Platform.IOS);
-        private static List<AdapterSelection> AddNewNetworks(Platform platform)
+        public static List<AdapterSelection> AddNewAndroidNetworks(Func<string, Dictionary<string, AdapterSelection>, bool> condition) => AddNewNetworks(Platform.Android, condition);
+        public static List<AdapterSelection> AddNewIOSNetworks(Func<string, Dictionary<string, AdapterSelection>, bool> condition) => AddNewNetworks(Platform.IOS, condition);
+        public static List<AdapterSelection> AddAllNewNetworks(Func<string, Dictionary<string, AdapterSelection>, bool>  condition) => AddNewNetworks(Platform.Android | Platform.IOS, condition);
+        private static List<AdapterSelection> AddNewNetworks(Platform platform, Func<string, Dictionary<string, AdapterSelection>, bool> condition)
         {
             var newNetworks = new List<AdapterSelection>();
 
             foreach (var network in PartnerSDKVersions)
             {
                 var id = network.Key;
-                if (UserSelectedVersions.ContainsKey(id)) 
+                if (condition(id, UserSelectedVersions))
                     continue;
                 
                 const int latestVersion = 1;
                 const int unselected = 0;
-                
-                var selection = new AdapterSelection(id);
 
+                var selection = new AdapterSelection(id);
                 var addAndroid = new Action(() => {
                     var androidVersions = network.Value.android;
                     if (androidVersions.Length > unselected)

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
@@ -36,8 +36,10 @@ namespace Chartboost.Editor.Adapters
             return same;
         }
 
-        public static void AddNewNetworks()
+        public static List<AdapterSelection> AddNewNetworks()
         {
+            var newNetworks = new List<AdapterSelection>();
+
             foreach (var network in PartnerSDKVersions)
             {
                 var id = network.Key;
@@ -54,6 +56,7 @@ namespace Chartboost.Editor.Adapters
                 var iosVersions = network.Value.ios;
                 if (iosVersions.Length > unselected)
                     selection.ios = iosVersions[latestVersion];
+                newNetworks.Add(selection);
                 UserSelectedVersions.Add(id, selection);
             }
             
@@ -61,6 +64,7 @@ namespace Chartboost.Editor.Adapters
             MediationSelection = package.version;
             GenerateChartboostMediationDependency();
             GenerateDependenciesFromSelections();
+            return newNetworks;
         }
 
         public static List<AdapterChange> UpgradeAndroidSelectionsToLatest() => UpgradePlatformToLatest(Platform.Android);

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowUtilities.cs
@@ -5,7 +5,6 @@ using UnityEditor;
 using UnityEngine;
 using Chartboost.Editor.Adapters.Comparers;
 using Chartboost.Editor.Adapters.Serialization;
-using Newtonsoft.Json;
 
 namespace Chartboost.Editor.Adapters
 {
@@ -54,7 +53,8 @@ namespace Chartboost.Editor.Adapters
                 const int latestVersion = 1;
                 const int unselected = 0;
 
-                var selection = new AdapterSelection(id);
+                var selection = !UserSelectedVersions.ContainsKey(id) ? new AdapterSelection(id) : UserSelectedVersions[id];
+                 
                 var addAndroid = new Action(() => {
                     var androidVersions = network.Value.android;
                     if (androidVersions.Length > unselected)
@@ -82,7 +82,7 @@ namespace Chartboost.Editor.Adapters
                 }
 
                 newNetworks.Add(selection);
-                UserSelectedVersions.Add(id, selection);
+                UserSelectedVersions[id] = selection;
             }
             
             var package = Utilities.FindPackage(Constants.ChartboostMediationPackageName);


### PR DESCRIPTION
# Description

I am hopeful this will be the last PR for CI/CD related stuff. I cleaned up some of the files, and reported the changes the methods

The utilization of the API should look like the following

```csharp

// Condition by which networks are skipped when trying to add new networks, in the condition below we add any network that is missing or partially implemented.
private static bool NetworkSkipCondition(string id, Dictionary<string, AdapterSelection> selections) => selections.ContainsKey(id) && selections[id].android != Constants.Unselected && selections[id].ios != Constants.Unselected;

// Update Adapters Information
AdapterDataSource.Update();

// Load Current Adapter Selections
AdaptersWindow.LoadSelections();

// Perform Adapter Upgrades
var upgrades = AdaptersWindow.UpgradePlatformToLatest(Platform.Android | Platform.IOS);

// Upgrades can be Logged
Log(upgrades.Count > 0 ? $"[Adapters] Upgraded: \n {JsonConvert.SerializeObject(upgrades, Formatting.Indented)}" : "[Adapters] No Upgrades.");

// Save Adapter Upgrades
AdaptersWindow.SaveSelections();

// Add New Networks
var newNetworks = AdaptersWindow.AddNewNetworks(Platform.Android | Platform.IOS,  NetworkAdditionCondition);

// Newly Added Networks can be Logged
Log(newNetworks.Count > 0 ? $"[Adapters] New Networks: \n {JsonConvert.SerializeObject(newNetworks, Formatting.Indented)}" :  "[Adapters] No New Networks");

// Check if Chartboost Mediation Version matches Package, if not make it match
var changed = AdaptersWindow.CheckChartboostMediationVersion();

// Change can be logged
Log(changed ? "[Adapters] Chartboost Mediation Version Has Been Updated" :  "[Adapters] Chartboost Mediation Version is Up to Date");
```