### PR TITLE
[HB-5824] Possible Fix for InMobi issue

### DIFF
--- a/com.chartboost.mediation.demo/Assets/Plugins/Android/mainTemplate.gradle
+++ b/com.chartboost.mediation.demo/Assets/Plugins/Android/mainTemplate.gradle
@@ -40,27 +40,28 @@ dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:11
     implementation 'androidx.multidex:multidex:2.0.1' // Assets/Demo/Editor/MultidexDependencies.xml:4
     implementation 'com.adcolony:sdk:4.8.0' // Assets/com.chartboost.mediation/Editor/Adapters/AdColonyDependencies.xml:8
-    implementation 'com.amazon.android:aps-sdk:9.7.0' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:8
-    implementation 'com.applovin:applovin-sdk:11.8.1' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:8
+    implementation 'com.amazon.android:aps-sdk:9.7.1' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:8
+    implementation 'com.applovin:applovin-sdk:11.8.2' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:8
     implementation 'com.chartboost:chartboost-mediation-adapter-adcolony:4.4.8.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AdColonyDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-admob:4.21.5.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AdMobDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.2+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-chartboost:4.9.2.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.2+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-google-bidding:4.21.5.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-inmobi:4.10.1.3+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-ironsource:4.7.2.7.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.12.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.0.3+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.4+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.0.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.13.7+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-mintegral:4.16.3.91+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-pangle:4.4.9.1.3+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/PangleDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-tapjoy:4.12.11.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/TapjoyDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-vungle:4.6.12.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/VungleDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-yahoo:4.1.4.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/YahooDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-sdk:4.2+' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:10
     implementation 'com.chartboost:chartboost-sdk:9.2.1' // Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml:8
-    implementation 'com.facebook.android:audience-network-sdk:6.12.0' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:8
+    implementation 'com.facebook.android:audience-network-sdk:6.13.7' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:8
     implementation 'com.fyber:marketplace-sdk:8.2.2' // Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml:8
     implementation 'com.google.android.gms:play-services-ads:21.5.0' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:8
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:15
@@ -68,8 +69,9 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:14
     implementation 'com.google.android.gms:play-services-basement:18.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:17
     implementation 'com.google.guava:guava:31.1-android' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:10
-    implementation 'com.inmobi.monetization:inmobi-ads:10.1.3' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:8
-    implementation 'com.ironsource.sdk:mediationsdk:7.2.7' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:8
+    implementation 'com.hyprmx.android:HyprMX-SDK:6.0.3' // Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml:8
+    implementation 'com.inmobi.monetization:inmobi-ads-kotlin:10.5.4' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:8
+    implementation 'com.ironsource.sdk:mediationsdk:7.3.0' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:8
     implementation 'com.mbridge.msdk.oversea:interstitialvideo:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:21
     implementation 'com.mbridge.msdk.oversea:mbbanner:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:24
     implementation 'com.mbridge.msdk.oversea:mbbid:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:25
@@ -83,7 +85,7 @@ dependencies {
     implementation 'com.mbridge.msdk.oversea:videojs:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:15
     implementation 'com.pangle.global:ads-sdk:4.9.1.3' // Assets/com.chartboost.mediation/Editor/Adapters/PangleDependencies.xml:8
     implementation 'com.tapjoy:tapjoy-android-sdk:12.11.1' // Assets/com.chartboost.mediation/Editor/Adapters/TapjoyDependencies.xml:8
-    implementation 'com.unity3d.ads:unity-ads:4.6.0' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:8
+    implementation 'com.unity3d.ads:unity-ads:4.6.1' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:8
     implementation 'com.vungle:publisher-sdk-android:6.12.1' // Assets/com.chartboost.mediation/Editor/Adapters/VungleDependencies.xml:8
     implementation 'com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.4.0' // Assets/com.chartboost.mediation/Editor/Adapters/YahooDependencies.xml:8
 // Android Resolver Dependencies End

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dependencies>
+    <androidPackages>
+        <!-- Android Adapter -->
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.0.3+@aar"/>
+
+        <!-- Partner Android SDK-->
+        <androidPackage spec="com.hyprmx.android:HyprMX-SDK:6.0.3"/>
+        
+    </androidPackages>
+    <iosPods>
+        <!-- iOS Adapter -->
+        <iosPod name="ChartboostMediationAdapterHyprMX" version="~> 4.6.0.0"/>
+
+        <!-- Partner iOS SDK-->
+        <iosPod name="HyprMX" version="~> 6.0.0" addToAllTargets="false"/>
+    </iosPods>
+</dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml.meta
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b05fab4c470c540d8ae66fac5a80746b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml
@@ -2,10 +2,10 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-inmobi:4.10.1.3+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.4+@aar"/>
 
         <!-- Partner Android SDK-->
-        <androidPackage spec="com.inmobi.monetization:inmobi-ads:10.1.3"/>
+        <androidPackage spec="com.inmobi.monetization:inmobi-ads-kotlin:10.5.4"/>
         
     </androidPackages>
     <iosPods>
@@ -13,6 +13,6 @@
         <iosPod name="ChartboostMediationAdapterInMobi" version="~> 4.10.5.0"/>
 
         <!-- Partner iOS SDK-->
-        <!-- InMobi species different SDKs based on version. Ignoring. -->
+        <iosPod name="InMobiSDK-Swift" version="~> 10.5.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml
@@ -14,9 +14,9 @@
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterIronSource" version="~> 4.7.2.7.0"/>
+        <iosPod name="ChartboostMediationAdapterIronSource" version="~> 4.7.3.0.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="IronSourceSDK" version="~> 7.2.7.0" addToAllTargets="false"/>
+        <iosPod name="IronSourceSDK" version="~> 7.3.0.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/selections.json
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/selections.json
@@ -38,13 +38,13 @@
     },
     {
       "id": "inmobi",
-      "android": "10.1.3",
+      "android": "10.5.4",
       "ios": "10.5.0"
     },
     {
       "id": "ironsource",
       "android": "7.3.0.0",
-      "ios": "7.2.7.0"
+      "ios": "7.3.0.0"
     },
     {
       "id": "meta",
@@ -80,6 +80,11 @@
       "id": "yahoo",
       "android": "1.4.0",
       "ios": "1.4.0"
+    },
+    {
+      "id": "hyprmx",
+      "android": "6.0.3",
+      "ios": "6.0.0"
     }
   ]
 }

--- a/com.chartboost.mediation.demo/ProjectSettings/AndroidResolverDependencies.xml
+++ b/com.chartboost.mediation.demo/ProjectSettings/AndroidResolverDependencies.xml
@@ -4,27 +4,28 @@
     <package>androidx.localbroadcastmanager:localbroadcastmanager:1.1.0</package>
     <package>androidx.multidex:multidex:2.0.1</package>
     <package>com.adcolony:sdk:4.8.0</package>
-    <package>com.amazon.android:aps-sdk:9.7.0</package>
-    <package>com.applovin:applovin-sdk:11.8.1</package>
+    <package>com.amazon.android:aps-sdk:9.7.1</package>
+    <package>com.applovin:applovin-sdk:11.8.2</package>
     <package>com.chartboost:chartboost-mediation-adapter-adcolony:4.4.8.0+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-admob:4.21.5.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.1+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.1+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.2+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-chartboost:4.9.2.1+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.2+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-google-bidding:4.21.5.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-inmobi:4.10.1.3+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-ironsource:4.7.2.7.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.12.0+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.0.3+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.4+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.0.0+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.13.7+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-mintegral:4.16.3.91+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-pangle:4.4.9.1.3+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-tapjoy:4.12.11.1+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.0+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.1+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-vungle:4.6.12.1+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-yahoo:4.1.4.0+@aar</package>
     <package>com.chartboost:chartboost-mediation-sdk:4.2+</package>
     <package>com.chartboost:chartboost-sdk:9.2.1</package>
-    <package>com.facebook.android:audience-network-sdk:6.12.0</package>
+    <package>com.facebook.android:audience-network-sdk:6.13.7</package>
     <package>com.fyber:marketplace-sdk:8.2.2</package>
     <package>com.google.android.gms:play-services-ads:21.5.0</package>
     <package>com.google.android.gms:play-services-ads-identifier:18.0.1</package>
@@ -32,8 +33,9 @@
     <package>com.google.android.gms:play-services-base:18.1.0</package>
     <package>com.google.android.gms:play-services-basement:18.1.0</package>
     <package>com.google.guava:guava:31.1-android</package>
-    <package>com.inmobi.monetization:inmobi-ads:10.1.3</package>
-    <package>com.ironsource.sdk:mediationsdk:7.2.7</package>
+    <package>com.hyprmx.android:HyprMX-SDK:6.0.3</package>
+    <package>com.inmobi.monetization:inmobi-ads-kotlin:10.5.4</package>
+    <package>com.ironsource.sdk:mediationsdk:7.3.0</package>
     <package>com.mbridge.msdk.oversea:interstitialvideo:16.3.91</package>
     <package>com.mbridge.msdk.oversea:mbbanner:16.3.91</package>
     <package>com.mbridge.msdk.oversea:mbbid:16.3.91</package>
@@ -47,7 +49,7 @@
     <package>com.mbridge.msdk.oversea:videojs:16.3.91</package>
     <package>com.pangle.global:ads-sdk:4.9.1.3</package>
     <package>com.tapjoy:tapjoy-android-sdk:12.11.1</package>
-    <package>com.unity3d.ads:unity-ads:4.6.0</package>
+    <package>com.unity3d.ads:unity-ads:4.6.1</package>
     <package>com.vungle:publisher-sdk-android:6.12.1</package>
     <package>com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.4.0</package>
   </packages>

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowSerialization.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowSerialization.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -131,6 +132,14 @@ namespace Chartboost.Editor.Adapters
                         sdkVersion = sdkVersion.Remove(sdkVersion.Length - 2, 2);
                     
                     var androidDependency = $"{adapter.android.adapter}:4.{adapterVersion}+@aar";
+                    
+                    if (adapterId.Equals(Constants.InMobi))
+                    {
+                        var version = new Version(sdkVersion);
+                        if (version >= Constants.InMobiNewSDK)
+                            sdk = $"{sdk}-kotlin";
+                    }
+
                     var androidSDKDependency = $"{sdk}:{sdkVersion}";
                     
                     template[androidAdapterIndexInTemplate] = template[androidAdapterIndexInTemplate].Replace(androidAdapterInTemplate, androidDependency);
@@ -191,17 +200,22 @@ namespace Chartboost.Editor.Adapters
                 var iosAdapterIndexInTemplate = template.FindIndex(x => x.Contains(iosAdapterInTemplate));
                 var iosSDKIndexInTemplate = template.FindIndex(x => x.Contains(iosSDKInTemplate));
 
-                var iosSelection = selection.Value.ios;
-                if (iosSelection != Constants.Unselected)
+                var iosSDKVersion = selection.Value.ios;
+                if (iosSDKVersion != Constants.Unselected)
                 {
-                    var iosDependency = $"4.{iosSelection}";
-                    template[iosAdapterIndexInTemplate] = template[iosAdapterIndexInTemplate].Replace(iosAdapterInTemplate, adapter.ios.adapter).Replace(iosAdapterVersionInTemplate, iosDependency);
+                    var iosAdapterVersion = $"4.{iosSDKVersion}";
+                    template[iosAdapterIndexInTemplate] = template[iosAdapterIndexInTemplate].Replace(iosAdapterInTemplate, adapter.ios.adapter).Replace(iosAdapterVersionInTemplate, iosAdapterVersion);
+
+                    var sdkNaming = adapter.ios.sdk;
                     
-                    // Handling InMobi quirk
-                    if (adapterId != Constants.InMobi)
-                        template[iosSDKIndexInTemplate] = template[iosSDKIndexInTemplate].Replace(iosSDKInTemplate, adapter.ios.sdk).Replace(iosSDKVersionInTemplate, iosSelection).Replace(iosAllTargetsInTemplate, adapter.ios.allTargets.ToString().ToLower());
-                    else
-                        template[iosSDKIndexInTemplate] = $"        <!-- {adapter.name} species different SDKs based on version. Ignoring. -->";
+                    if (adapterId.Equals(Constants.InMobi))
+                    {
+                        var version = new Version(iosSDKVersion);
+                        if (version >= Constants.InMobiNewSDK)
+                            sdkNaming = $"{sdkNaming}-Swift";
+                    }
+                    
+                    template[iosSDKIndexInTemplate] = template[iosSDKIndexInTemplate].Replace(iosSDKInTemplate, sdkNaming).Replace(iosSDKVersionInTemplate, iosSDKVersion).Replace(iosAllTargetsInTemplate, adapter.ios.allTargets.ToString().ToLower());
                 }
                 else
                 {

--- a/com.chartboost.mediation/Editor/Adapters/Constants.cs
+++ b/com.chartboost.mediation/Editor/Adapters/Constants.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using UnityEngine;
 
@@ -27,6 +28,7 @@ namespace Chartboost.Editor.Adapters
         public const string InMobi = "inmobi";
         public const string IronSource = "ironsource";
         public const string Mintegral = "mintegral";
+        public static readonly Version InMobiNewSDK = new Version("10.5.0");
 
         public const string StyleSheet = "Packages/com.chartboost.mediation/Editor/Adapters/Visuals/AdaptersWindow.uss";
         public const string LogoPNG = "Packages/com.chartboost.mediation/Editor/Adapters/Visuals/Logo.png";


### PR DESCRIPTION
# Description

Currently our partners.json file only supports 1 main SDK dependency for partners. 

## Android
For InMobi 10.X such dependency is `com.inmobi.monetization:inmobi-ads`

While for InMobi 10.5.X such dependency is `com.inmobi.monetization:inmobi-ads-kotlin`

## IOS

For InMobi 10.X such dependency is `InMobiSDK`

While for InMobi 10.5.X such dependency is `InMobiSDK-Swift`
