### PR TITLE
[HB-5916] Fixing Invalidate Getting Called Multiple Times Would Cause a Crash

### DIFF
--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml
@@ -18,7 +18,7 @@
     </androidPackages>
     <iosPods>
         <!-- Chartboost Mediation iOS SDK -->
-        <iosPod name="ChartboostMediationSDK" version="~> 4.3">
+        <iosPod name="ChartboostMediationSDK" version="~> 4.3.0">
             <sources>
                 <source>https://github.com/CocoaPods/Specs</source>
             </sources>

--- a/com.chartboost.mediation/Editor/Adapters/AdaptersWindowSerialization.cs
+++ b/com.chartboost.mediation/Editor/Adapters/AdaptersWindowSerialization.cs
@@ -239,10 +239,13 @@ namespace Chartboost.Editor.Adapters
             var defaultTemplateContents = Constants.PathToMainTemplate.ReadAllLines().ToList();
             var androidVersionIndex = defaultTemplateContents.FindIndex(x => x.Contains(Constants.AndroidVersionInMainTemplate));
             var iosVersionIndex = defaultTemplateContents.FindIndex(x => x.Contains(Constants.IOSVersionInMainTemplate));
-
-            var optimisticVersion = MediationSelection.Remove(MediationSelection.Length - 2);
-            defaultTemplateContents[androidVersionIndex] = defaultTemplateContents[androidVersionIndex].Replace(Constants.AndroidVersionInMainTemplate, optimisticVersion);
-            defaultTemplateContents[iosVersionIndex] = defaultTemplateContents[iosVersionIndex].Replace(Constants.IOSVersionInMainTemplate, optimisticVersion);
+            
+            var androidOptimisticVersion = MediationSelection.Remove(MediationSelection.Length - 2);
+            defaultTemplateContents[androidVersionIndex] = defaultTemplateContents[androidVersionIndex].Replace(Constants.AndroidVersionInMainTemplate, androidOptimisticVersion);
+            
+            var lastDigit = MediationSelection.Length - 1;
+            var iosOptimisticVersion = MediationSelection.Remove(lastDigit).Insert(lastDigit, "0");
+            defaultTemplateContents[iosVersionIndex] = defaultTemplateContents[iosVersionIndex].Replace(Constants.IOSVersionInMainTemplate, iosOptimisticVersion);
 
             Constants.PathToPackageGeneratedFiles.DirectoryCreate();
             Constants.PathToEditorInGeneratedFiles.DirectoryCreate();

--- a/com.chartboost.mediation/Runtime/AdFormats/Fullscreen/ChartboostMediationFullscreenAdAndroid.cs
+++ b/com.chartboost.mediation/Runtime/AdFormats/Fullscreen/ChartboostMediationFullscreenAdAndroid.cs
@@ -59,7 +59,7 @@ namespace Chartboost.AdFormats.Fullscreen
             if (!_isValid)
                 return;
 
-            _isValid = true;
+            _isValid = false;
             _chartboostMediationFullscreenAd.Call("invalidate");
             _chartboostMediationFullscreenAd.Dispose();
             CacheManager.ReleaseFullscreenAd(_hashCode);


### PR DESCRIPTION
# Description

Invalidate is a one off thing. The Boolean value was never set correctly so it could get called multiple times causing the application to try to call `invalidate` in the native ad multiple times. This would be bad since the ad reference would have be gone by then. 