### PR TITLE
[HB-5946] Adding New Networks to Partner Killswitch

### DIFF
--- a/com.chartboost.mediation/Runtime/ChartboostMediationSettings.cs
+++ b/com.chartboost.mediation/Runtime/ChartboostMediationSettings.cs
@@ -30,7 +30,10 @@ namespace Chartboost
         [Description("tapjoy")] TapJoy = 2048,
         [Description("unity")] UnityAds = 4096,
         [Description("vungle")] Vungle = 8192,
-        [Description("yahoo")] Yahoo = 16384
+        [Description("yahoo")] Yahoo = 16384,
+        [Description("mobilefuse")] MobileFuse = 32768,
+        [Description("verve")] Verve = 65536,
+        [Description("hyprmx")] HyprMX = 131072
     }
 
     /// <summary>


### PR DESCRIPTION
# Description

This PR adds the newly released or incoming networks to the enum flag. This enum approach will most likely be deprecated in the future for a string based approach since SDK release & Adapters Releases do not follow the same cadence anymore.
