### PR TITLE
[HB-6114] Deprecating old Kill-Switch and Adding New Initialization Method

### DIFF
--- a/com.chartboost.mediation.demo/Assets/Demo/Demo.cs
+++ b/com.chartboost.mediation.demo/Assets/Demo/Demo.cs
@@ -59,7 +59,7 @@ public class Demo : MonoBehaviour
         fullscreenPlacementInputField.SetTextWithoutNotify(DefaultPlacementFullscreen);
         bannerPlacementInputField.SetTextWithoutNotify(DefaultPlacementBanner);
 
-        ChartboostMediation.StartWithAppIdAndAppSignature(ChartboostMediationSettings.AppId, ChartboostMediationSettings.AppSignature);
+        ChartboostMediation.StartWithOptions(ChartboostMediationSettings.AppId, ChartboostMediationSettings.AppSignature);
     }
 
     private void OnDestroy()

--- a/com.chartboost.mediation/Editor/ChartboostMediationSettingsEditor.cs
+++ b/com.chartboost.mediation/Editor/ChartboostMediationSettingsEditor.cs
@@ -48,7 +48,7 @@ namespace Chartboost.Editor
 			EditorGUILayout.BeginVertical();
 			EditorGUILayout.LabelField(_partnerKilLSwitchTitle, _title);
 			EditorGUILayout.Space();
-			EditorGUILayout.HelpBox("Select partners to disable their initialization.", MessageType.Info);
+			EditorGUILayout.HelpBox("Select partners to disable their initialization.\n(Enum flag has been deprecated and will be removed in future versions, use StartWithOptions instead)", MessageType.Info);
 			ChartboostMediationSettings.PartnerKillSwitch = (ChartboostMediationPartners)EditorGUILayout.EnumFlagsField(ChartboostMediationSettings.PartnerKillSwitch);
 			EditorGUILayout.EndVertical();
 			

--- a/com.chartboost.mediation/Runtime/Adapters.cs
+++ b/com.chartboost.mediation/Runtime/Adapters.cs
@@ -1,0 +1,24 @@
+namespace Chartboost
+{
+    public static class Adapters
+    {
+        public const string AdColony = "adcolony";
+        public const string AdMob = "admob";
+        public const string AmazonPublisherServices = "amazon_aps";
+        public const string AppLovin = "applovin";
+        public const string MetaAudienceNetwork = "facebook";
+        public const string DigitalTurbineExchange = "fyber";
+        public const string GoogleBidding = "google_googlebidding";
+        public const string InMobi = "inmobi";
+        public const string IronSource = "ironsource";
+        public const string Mintegral = "mintegral";
+        public const string Pangle = "pangle";
+        public const string Tapjoy = "tapjoy";
+        public const string Unity = "unity";
+        public const string Vungle = "vungle";
+        public const string Yahoo = "yahoo";
+        public const string MobileFuse = "mobilefuse";
+        public const string Verve = "verve";
+        public const string HyprMX = "hyprmx";
+    }
+}

--- a/com.chartboost.mediation/Runtime/Adapters.cs.meta
+++ b/com.chartboost.mediation/Runtime/Adapters.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 4150815d5ebb421bbd2c10eb8c0a10f0
+timeCreated: 1688054396

--- a/com.chartboost.mediation/Runtime/ChartboostMediation.cs
+++ b/com.chartboost.mediation/Runtime/ChartboostMediation.cs
@@ -221,10 +221,17 @@ namespace Chartboost
                 _chartboostMediationExternal.Init();
         }
 
+        [Obsolete("StartWithAppIdAndAppSignature is obsolete and will be removed in future versions, please use StartWithOptions instead.")]
         public static void StartWithAppIdAndAppSignature(string appId, string appSignature)
         {
             if (!ChartboostMediationExternal.IsInitialized)
                 _chartboostMediationExternal.InitWithAppIdAndSignature(appId, appSignature);
+        }
+
+        public static void StartWithOptions(string appId, string appSignature, string[] options = null)
+        {
+            if (!ChartboostMediationExternal.IsInitialized)
+                _chartboostMediationExternal.InitWithOptions(appId, appSignature, options);
         }
 
         public static void SetSubjectToCoppa(bool isSubject) => _chartboostMediationExternal.SetSubjectToCoppa(isSubject);

--- a/com.chartboost.mediation/Runtime/ChartboostMediationSettings.cs
+++ b/com.chartboost.mediation/Runtime/ChartboostMediationSettings.cs
@@ -13,6 +13,7 @@ namespace Chartboost
     /// List of officially supported Chartboost Mediation mediation partners and their identifiers
     /// </summary>
     [Flags]
+    [Obsolete("ChartboostMediationPartners has been deprecated, please use StartWithOptions instead.")]
     public enum ChartboostMediationPartners
     {
         [Description("none")] None = 0,
@@ -127,6 +128,7 @@ namespace Chartboost
         /// <summary>
         /// Accessor for partnerKillSwitch. 
         /// </summary>
+        [Obsolete("PartnerKillSwitch has been deprecated and will be removed in future versions, please use StartWithOptions instead.")]
         public static ChartboostMediationPartners PartnerKillSwitch
         {
             get => Instance.partnerKillSwitch;

--- a/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.cs
@@ -1,5 +1,6 @@
 #if UNITY_ANDROID
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using Chartboost.Events;
 using Chartboost.Requests;
@@ -56,6 +57,20 @@ namespace Chartboost.Platforms.Android
             using var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
             var initializationOptions = GetInitializationOptions().ArrayToInitializationOptions();
             nativeSDK.CallStatic("start", activity, appId, appSignature, initializationOptions,  new ChartboostMediationSDKListener());
+            IsInitialized = true;
+        }
+
+        public override void StartWithOptions(string appId, string appSignature, string[] initializationOptions = null)
+        {
+            base.StartWithOptions(appId, appSignature, initializationOptions);
+            ChartboostMediationSettings.AndroidAppId = appId;
+            ChartboostMediationSettings.AndroidAppSignature = appSignature;
+            initializationOptions ??= Array.Empty<string>();
+            var nativeOptions = initializationOptions.ArrayToInitializationOptions();
+            using var nativeSDK = GetNativeSDK();
+            using var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
+            using var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
+            nativeSDK.CallStatic("start", activity, appId, appSignature, nativeOptions,  new ChartboostMediationSDKListener());
             IsInitialized = true;
         }
 

--- a/com.chartboost.mediation/Runtime/Platforms/ChartboostMediationExternal.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/ChartboostMediationExternal.cs
@@ -7,6 +7,7 @@ using Chartboost.Banner;
 using Chartboost.FullScreen.Interstitial;
 using Chartboost.FullScreen.Rewarded;
 using Chartboost.Requests;
+using Newtonsoft.Json;
 using UnityEngine;
 using Logger = Chartboost.Utilities.Logger;
 
@@ -44,11 +45,13 @@ namespace Chartboost.Platforms
 
         /// Initialize the Chartboost Mediation plugin with a specific appId
         /// Either one of the init() methods must be called before using any other Chartboost Mediation feature
-        public virtual void InitWithAppIdAndSignature(string appId, string appSignature)
-        {
-            Logger.Log(LogTag, $"InitWithAppIdAndSignature {appId}, {appSignature} and version {Application.unityVersion}");
-        }
-        
+        [Obsolete("InitWithAppIdAndSignature has been deprecated, please use InitWithOptions instead")]
+        public virtual void InitWithAppIdAndSignature(string appId, string appSignature) 
+            => Logger.Log(LogTag, $"InitWithAppIdAndSignature {appId}, {appSignature} and version {Application.unityVersion}");
+
+        public virtual void InitWithOptions(string appId, string appSignature, string[] initializationOptions = null) 
+            => Logger.Log(LogTag, $"InitWithAppIdAndSignature {appId}, {appSignature} and version {JsonConvert.SerializeObject(initializationOptions)}");
+
         public virtual void SetSubjectToCoppa(bool isSubject) 
             => Logger.Log(LogTag, $"SetSubjectToCoppa {isSubject}");
 

--- a/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.cs
@@ -1,4 +1,5 @@
 #if UNITY_IPHONE
+using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Chartboost.Requests;
@@ -82,6 +83,16 @@ namespace Chartboost.Platforms.IOS
             ChartboostMediationSettings.IOSAppId = appId;
             ChartboostMediationSettings.IOSAppSignature = appSignature;
             var initializationOptions = GetInitializationOptions();
+            _chartboostMediationInit(appId, appSignature, Application.unityVersion, initializationOptions, initializationOptions.Length);
+            IsInitialized = true;
+        }
+
+        public override void InitWithOptions(string appId, string appSignature, string[] initializationOptions = null)
+        {
+            base.InitWithOptions(appId, appSignature, initializationOptions);
+            ChartboostMediationSettings.IOSAppId = appId;
+            ChartboostMediationSettings.IOSAppSignature = appSignature;
+            initializationOptions ??= Array.Empty<string>();
             _chartboostMediationInit(appId, appSignature, Application.unityVersion, initializationOptions, initializationOptions.Length);
             IsInitialized = true;
         }


### PR DESCRIPTION
# Description

Chartboost Mediation Unity SDK’s current approach to initialization options is to utilize a Enum flag setup in the `ChartboostMediationSettings.cs`. This was a good approach when adapters were tied to SDK releases, and limited to certain networks. However, since the 4.X series, the SDK is no longer released at the same cadence as adapters; and there is the additional possibility of users creating custom adapters. As such, the Enum flag approach is obsolete and can’t support such scenarios with ease. We will simplify this by providing a new initialization method, in which users can pass optional initialization parameters. 

The network kill-switch will only be available if users initialize manually, if they make use of the automatic init, this won’t be taken into account. Notice that automatic init for the Unity SDK is completely optional and disabled by default.