### PR TITLE
[HB-6168] Fixing Bug with Build-Postprocessor

### DIFF
--- a/com.chartboost.mediation/Editor/BuildTools/ChartboostMediationPostprocessor.cs
+++ b/com.chartboost.mediation/Editor/BuildTools/ChartboostMediationPostprocessor.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
-using UnityEditor.Callbacks;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
 #if UNITY_IOS
 using System.Collections.Generic;
 using UnityEditor.iOS.Xcode;
@@ -11,11 +12,14 @@ using Chartboost.Editor.SKAdNetwork;
 
 namespace Chartboost.Editor.BuildTools
 {
-    internal sealed class ChartboostMediationPostprocessor
+    internal sealed class ChartboostMediationPostprocessor : IPostprocessBuildWithReport
     {
-        [PostProcessBuild]
-        public static void PostProcess(BuildTarget buildTarget, string pathToBuiltProject)
+        public int callbackOrder { get; }
+        public void OnPostprocessBuild(BuildReport report)
         {
+            var buildTarget = report.summary.platform;
+            var pathToBuiltProject = report.summary.outputPath;
+            
             if (buildTarget != BuildTarget.iOS)
                 return;
             

--- a/com.chartboost.mediation/Editor/BuildTools/ChartboostMediationPreprocessor.cs
+++ b/com.chartboost.mediation/Editor/BuildTools/ChartboostMediationPreprocessor.cs
@@ -8,10 +8,9 @@ using UnityEngine;
 
 namespace Chartboost.Editor.BuildTools
 {
-    public class ChartboostMediationPreprocessor : IPreprocessBuildWithReport
+    internal class ChartboostMediationPreprocessor : IPreprocessBuildWithReport
     {
         public int callbackOrder { get; }
-        
         public void OnPreprocessBuild(BuildReport report)
         {
             if (report.summary.platform != BuildTarget.Android)


### PR DESCRIPTION
# Description

Using the `PostProcessBuild` attribute has issues when changing platforms on the fly using a builder script. Using the interface seems to work better and more consistently even when changing platforms programatically.