### PR TITLE
[HB-6205] Update Android Dependencies - iOS Verve & MobileFuse Dependencies

### DIFF
--- a/com.chartboost.mediation.demo/Assets/Plugins/Android/mainTemplate.gradle
+++ b/com.chartboost.mediation.demo/Assets/Plugins/Android/mainTemplate.gradle
@@ -23,6 +23,9 @@
             url "https://sdk.tapjoy.com/" // Assets/com.chartboost.mediation/Editor/Adapters/TapjoyDependencies.xml:13
         }
         maven {
+            url "https://verve.jfrog.io/artifactory/verve-gradle-release" // Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml:13
+        }
+        maven {
             url "https://artifactory.yahooinc.com/artifactory/maven/" // Assets/com.chartboost.mediation/Editor/Adapters/YahooDependencies.xml:13
         }
         maven {
@@ -43,38 +46,41 @@ dependencies {
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:11
     implementation 'androidx.multidex:multidex:2.0.1' // Assets/Demo/Editor/MultidexDependencies.xml:4
     implementation 'com.adcolony:sdk:4.8.0' // Assets/com.chartboost.mediation/Editor/Adapters/AdColonyDependencies.xml:8
-    implementation 'com.amazon.android:aps-sdk:9.7.1' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:8
-    implementation 'com.applovin:applovin-sdk:11.8.2' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:8
+    implementation 'com.amazon.android:aps-sdk:9.8.2' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:8
+    implementation 'com.applovin:applovin-sdk:11.10.1' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:8
     implementation 'com.chartboost:chartboost-mediation-adapter-adcolony:4.4.8.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AdColonyDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-admob:4.21.5.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AdMobDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.2+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-chartboost:4.9.3.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.2+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-google-bidding:4.21.5.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-admob:4.22.1.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AdMobDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.8.2+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-applovin:4.11.10.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-chartboost:4.9.3.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.3+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.1.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.0.3+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.4+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.13.7+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.5+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.14.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-mintegral:4.16.3.91+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-mobilefuse:4.1.4.4+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/MobileFuseDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-pangle:4.4.9.1.3+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/PangleDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-tapjoy:4.12.11.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/TapjoyDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.7.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:5
+    implementation 'com.chartboost:chartboost-mediation-adapter-verve:4.2.17.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-vungle:4.6.12.1+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/VungleDependencies.xml:5
     implementation 'com.chartboost:chartboost-mediation-adapter-yahoo:4.1.4.0+@aar' // Assets/com.chartboost.mediation/Editor/Adapters/YahooDependencies.xml:5
-    implementation 'com.chartboost:chartboost-mediation-sdk:4.3+' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:10
-    implementation 'com.chartboost:chartboost-sdk:9.3.0' // Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml:8
-    implementation 'com.facebook.android:audience-network-sdk:6.13.7' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:8
-    implementation 'com.fyber:marketplace-sdk:8.2.2' // Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml:8
-    implementation 'com.google.android.gms:play-services-ads:21.5.0' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:8
-    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:15
-    implementation 'com.google.android.gms:play-services-appset:16.0.2' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:16
-    implementation 'com.google.android.gms:play-services-base:18.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:14
-    implementation 'com.google.android.gms:play-services-basement:18.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:17
+    implementation 'com.chartboost:chartboost-mediation-sdk:4.4+' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:10
+    implementation 'com.chartboost:chartboost-sdk:9.3.1' // Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml:8
+    implementation 'com.facebook.android:audience-network-sdk:6.14.0' // Assets/com.chartboost.mediation/Editor/Adapters/MetaAudienceNetworkDependencies.xml:8
+    implementation 'com.fyber:marketplace-sdk:8.2.3' // Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml:8
+    implementation 'com.google.android.gms:play-services-ads:22.1.0' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:8
+    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:22
+    implementation 'com.google.android.gms:play-services-appset:16.0.2' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:23
+    implementation 'com.google.android.gms:play-services-base:18.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:21
+    implementation 'com.google.android.gms:play-services-basement:18.1.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:24
     implementation 'com.google.guava:guava:31.1-android' // Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml:9
     implementation 'com.hyprmx.android:HyprMX-SDK:6.0.3' // Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml:8
-    implementation 'com.inmobi.monetization:inmobi-ads-kotlin:10.5.4' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:8
-    implementation 'com.ironsource.sdk:mediationsdk:7.3.0' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:8
+    implementation 'com.inmobi.monetization:inmobi-ads-kotlin:10.5.5' // Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml:8
+    implementation 'com.ironsource.sdk:mediationsdk:7.3.1' // Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml:8
+    implementation 'com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:12
     implementation 'com.mbridge.msdk.oversea:interstitialvideo:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:14
     implementation 'com.mbridge.msdk.oversea:mbbanner:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:17
     implementation 'com.mbridge.msdk.oversea:mbbid:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:18
@@ -86,11 +92,19 @@ dependencies {
     implementation 'com.mbridge.msdk.oversea:same:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:13
     implementation 'com.mbridge.msdk.oversea:videocommon:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:12
     implementation 'com.mbridge.msdk.oversea:videojs:16.3.91' // Assets/com.chartboost.mediation/Editor/Adapters/MintegralDependencies.xml:8
+    implementation 'com.mobilefuse.sdk:mobilefuse-sdk-core:1.4.4' // Assets/com.chartboost.mediation/Editor/Adapters/MobileFuseDependencies.xml:8
     implementation 'com.pangle.global:ads-sdk:4.9.1.3' // Assets/com.chartboost.mediation/Editor/Adapters/PangleDependencies.xml:8
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:16
+    implementation 'com.squareup.okhttp3:okhttp:4.10.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:15
+    implementation 'com.squareup.retrofit2:converter-scalars:2.9.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:17
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:18
     implementation 'com.tapjoy:tapjoy-android-sdk:12.11.1' // Assets/com.chartboost.mediation/Editor/Adapters/TapjoyDependencies.xml:8
-    implementation 'com.unity3d.ads:unity-ads:4.6.1' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:8
+    implementation 'com.unity3d.ads:unity-ads:4.7.1' // Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml:8
     implementation 'com.vungle:publisher-sdk-android:6.12.1' // Assets/com.chartboost.mediation/Editor/Adapters/VungleDependencies.xml:8
     implementation 'com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.4.0' // Assets/com.chartboost.mediation/Editor/Adapters/YahooDependencies.xml:8
+    implementation 'net.pubnative:hybid.sdk:2.17.0' // Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml:8
+    implementation 'org.jetbrains.kotlin:kotlin-reflect:1.7.20' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:14
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1' // Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml:13
 // Android Resolver Dependencies End
 **DEPS**}
 

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/AdMobDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/AdMobDependencies.xml
@@ -2,16 +2,16 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-admob:4.21.5.0+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-admob:4.22.1.0+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.google.android.gms:play-services-ads:21.5.0"/>
+        <androidPackage spec="com.google.android.gms:play-services-ads:22.1.0"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterAdMob" version="~> 4.10.3.0"/>
+        <iosPod name="ChartboostMediationAdapterAdMob" version="~> 4.10.6.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="Google-Mobile-Ads-SDK" version="~> 10.3.0" addToAllTargets="false"/>
+        <iosPod name="Google-Mobile-Ads-SDK" version="~> 10.6.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/AmazonPublisherServicesDependencies.xml
@@ -2,16 +2,16 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.1+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.8.2+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.amazon.android:aps-sdk:9.7.1"/>
+        <androidPackage spec="com.amazon.android:aps-sdk:9.8.2"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterAmazonPublisherServices" version="~> 4.4.6.0"/>
+        <iosPod name="ChartboostMediationAdapterAmazonPublisherServices" version="~> 4.4.7.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="AmazonPublisherServicesSDK" version="~> 4.6.0" addToAllTargets="true"/>
+        <iosPod name="AmazonPublisherServicesSDK" version="~> 4.7.0" addToAllTargets="true"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/AppLovinDependencies.xml
@@ -2,16 +2,16 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.2+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-applovin:4.11.10.1+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.applovin:applovin-sdk:11.8.2"/>
+        <androidPackage spec="com.applovin:applovin-sdk:11.10.1"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterAppLovin" version="~> 4.11.8.0"/>
+        <iosPod name="ChartboostMediationAdapterAppLovin" version="~> 4.11.10.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="AppLovinSDK" version="~> 11.8.0" addToAllTargets="false"/>
+        <iosPod name="AppLovinSDK" version="~> 11.10.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/ChartboostDependencies.xml
@@ -2,10 +2,10 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-chartboost:4.9.3.0+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-chartboost:4.9.3.1+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.chartboost:chartboost-sdk:9.3.0"/>
+        <androidPackage spec="com.chartboost:chartboost-sdk:9.3.1"/>
 
         <!-- Chartboost Android Repositories -->
         <repositories>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/DigitalTurbineExchangeDependencies.xml
@@ -2,10 +2,10 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.2+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.3+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.fyber:marketplace-sdk:8.2.2"/>
+        <androidPackage spec="com.fyber:marketplace-sdk:8.2.3"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/GoogleBiddingDependencies.xml
@@ -2,17 +2,17 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-google-bidding:4.21.5.0+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.1.0+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.google.android.gms:play-services-ads:21.5.0"/>
+        <androidPackage spec="com.google.android.gms:play-services-ads:22.1.0"/>
         <androidPackage spec="com.google.guava:guava:31.1-android"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterGoogleBidding" version="~> 4.10.3.0"/>
+        <iosPod name="ChartboostMediationAdapterGoogleBidding" version="~> 4.10.6.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="Google-Mobile-Ads-SDK" version="~> 10.3.0" addToAllTargets="false"/>
+        <iosPod name="Google-Mobile-Ads-SDK" version="~> 10.6.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/HyprMXDependencies.xml
@@ -9,9 +9,9 @@
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterHyprMX" version="~> 4.6.0.0"/>
+        <iosPod name="ChartboostMediationAdapterHyprMX" version="~> 4.6.2.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="HyprMX" version="~> 6.0.0" addToAllTargets="true"/>
+        <iosPod name="HyprMX" version="~> 6.2.0" addToAllTargets="true"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/InMobiDependencies.xml
@@ -2,10 +2,10 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.4+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.5+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.inmobi.monetization:inmobi-ads-kotlin:10.5.4"/>
+        <androidPackage spec="com.inmobi.monetization:inmobi-ads-kotlin:10.5.5"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/IronSourceDependencies.xml
@@ -2,10 +2,10 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.0+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.1+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.ironsource.sdk:mediationsdk:7.3.0"/>
+        <androidPackage spec="com.ironsource.sdk:mediationsdk:7.3.1"/>
 
         <!-- IronSource Android Repositories -->
         <repositories>
@@ -14,9 +14,9 @@
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterIronSource" version="~> 4.7.3.0.0"/>
+        <iosPod name="ChartboostMediationAdapterIronSource" version="~> 4.7.3.1.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="IronSourceSDK" version="~> 7.3.0.0" addToAllTargets="false"/>
+        <iosPod name="IronSourceSDK" version="~> 7.3.1.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/MobileFuseDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/MobileFuseDependencies.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dependencies>
+    <androidPackages>
+        <!-- Android Adapter -->
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-mobilefuse:4.1.4.4+@aar"/>
+
+        <!-- Partner Android SDK Dependencies-->
+        <androidPackage spec="com.mobilefuse.sdk:mobilefuse-sdk-core:1.4.4"/>
+    </androidPackages>
+    <iosPods>
+        <!-- iOS Adapter -->
+        <iosPod name="ChartboostMediationAdapterMobileFuse" version="~> 4.1.4.4"/>
+
+        <!-- Partner iOS SDK-->
+        <iosPod name="MobileFuseSDK" version="~> 1.4.4" addToAllTargets="true"/>
+    </iosPods>
+</dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/MobileFuseDependencies.xml.meta
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/MobileFuseDependencies.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c795d1788e4b94066ad78314050fa3c6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/UnityAdsDependencies.xml
@@ -2,17 +2,17 @@
 <dependencies>
     <androidPackages>
         <!-- Android Adapter -->
-        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.1+@aar"/>
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.7.1+@aar"/>
 
         <!-- Partner Android SDK Dependencies-->
-        <androidPackage spec="com.unity3d.ads:unity-ads:4.6.1"/>
+        <androidPackage spec="com.unity3d.ads:unity-ads:4.7.1"/>
         <androidPackage spec="androidx.core:core:1.2.0"/>
     </androidPackages>
     <iosPods>
         <!-- iOS Adapter -->
-        <iosPod name="ChartboostMediationAdapterUnityAds" version="~> 4.4.6.0"/>
+        <iosPod name="ChartboostMediationAdapterUnityAds" version="~> 4.4.7.0"/>
 
         <!-- Partner iOS SDK-->
-        <iosPod name="UnityAds" version="~> 4.6.0" addToAllTargets="false"/>
+        <iosPod name="UnityAds" version="~> 4.7.0" addToAllTargets="false"/>
     </iosPods>
 </dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<dependencies>
+    <androidPackages>
+        <!-- Android Adapter -->
+        <androidPackage spec="com.chartboost:chartboost-mediation-adapter-verve:4.2.17.0+@aar"/>
+
+        <!-- Partner Android SDK Dependencies-->
+        <androidPackage spec="net.pubnative:hybid.sdk:2.17.0"/>
+
+        <!-- Verve Android Repositories -->
+        <repositories>
+          <repository>https://verve.jfrog.io/artifactory/verve-gradle-release</repository>
+        </repositories>
+    </androidPackages>
+    <iosPods>
+        <!-- iOS Adapter -->
+        <iosPod name="ChartboostMediationAdapterVerve" version="~> 4.2.18.0"/>
+
+        <!-- Partner iOS SDK-->
+        <iosPod name="HyBid" version="~> 2.18.0" addToAllTargets="true"/>
+    </iosPods>
+</dependencies>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml.meta
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/Adapters/VerveDependencies.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4ed13cfdc96974fd98fb830f4602cfa7
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/ChartboostMediationDependencies.xml
@@ -9,6 +9,13 @@
         <!-- Chartboost Mediation Android SDK -->
         <androidPackage spec="com.chartboost:chartboost-mediation-sdk:4.4+" />
         <androidPackage spec="androidx.localbroadcastmanager:localbroadcastmanager:1.1.0" />
+        <androidPackage spec="com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0" />
+        <androidPackage spec="org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1" />
+        <androidPackage spec="org.jetbrains.kotlin:kotlin-reflect:1.7.20" />
+        <androidPackage spec="com.squareup.okhttp3:okhttp:4.10.0" />
+        <androidPackage spec="com.squareup.okhttp3:logging-interceptor:4.10.0" />
+        <androidPackage spec="com.squareup.retrofit2:converter-scalars:2.9.0" />
+        <androidPackage spec="com.squareup.retrofit2:retrofit:2.9.0" />
 
         <!-- Google Play Services dependencies -->
         <androidPackage spec="com.google.android.gms:play-services-base:18.1.0"/>

--- a/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/selections.json
+++ b/com.chartboost.mediation.demo/Assets/com.chartboost.mediation/Editor/selections.json
@@ -8,43 +8,43 @@
     },
     {
       "id": "admob",
-      "android": "21.5.0",
-      "ios": "10.3.0"
+      "android": "22.1.0",
+      "ios": "10.6.0"
     },
     {
       "id": "aps",
-      "android": "9.7.1",
-      "ios": "4.6.0"
+      "android": "9.8.2",
+      "ios": "4.7.0"
     },
     {
       "id": "applovin",
-      "android": "11.8.2",
-      "ios": "11.8.0"
+      "android": "11.10.1",
+      "ios": "11.10.0"
     },
     {
       "id": "chartboost",
-      "android": "9.3.0",
+      "android": "9.3.1",
       "ios": "9.3.0"
     },
     {
       "id": "digitalturbine",
-      "android": "8.2.2",
+      "android": "8.2.3",
       "ios": "8.2.1"
     },
     {
       "id": "googlebidding",
-      "android": "21.5.0",
-      "ios": "10.3.0"
+      "android": "22.1.0",
+      "ios": "10.6.0"
     },
     {
       "id": "inmobi",
-      "android": "10.5.4",
+      "android": "10.5.5",
       "ios": "10.5.0"
     },
     {
       "id": "ironsource",
-      "android": "7.3.0.0",
-      "ios": "7.3.0.0"
+      "android": "7.3.1.0",
+      "ios": "7.3.1.0"
     },
     {
       "id": "meta",
@@ -68,8 +68,8 @@
     },
     {
       "id": "unityads",
-      "android": "4.6.1",
-      "ios": "4.6.0"
+      "android": "4.7.1",
+      "ios": "4.7.0"
     },
     {
       "id": "vungle",
@@ -84,7 +84,17 @@
     {
       "id": "hyprmx",
       "android": "6.0.3",
-      "ios": "6.0.0"
+      "ios": "6.2.0"
+    },
+    {
+      "id": "verve",
+      "android": "2.17.0",
+      "ios": "2.18.0"
+    },
+    {
+      "id": "mobilefuse",
+      "android": "1.4.4",
+      "ios": "1.4.4"
     }
   ]
 }

--- a/com.chartboost.mediation.demo/ProjectSettings/AndroidResolverDependencies.xml
+++ b/com.chartboost.mediation.demo/ProjectSettings/AndroidResolverDependencies.xml
@@ -4,38 +4,41 @@
     <package>androidx.localbroadcastmanager:localbroadcastmanager:1.1.0</package>
     <package>androidx.multidex:multidex:2.0.1</package>
     <package>com.adcolony:sdk:4.8.0</package>
-    <package>com.amazon.android:aps-sdk:9.7.1</package>
-    <package>com.applovin:applovin-sdk:11.8.2</package>
+    <package>com.amazon.android:aps-sdk:9.8.2</package>
+    <package>com.applovin:applovin-sdk:11.10.1</package>
     <package>com.chartboost:chartboost-mediation-adapter-adcolony:4.4.8.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-admob:4.21.5.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.7.1+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-applovin:4.11.8.2+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-chartboost:4.9.3.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.2+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-google-bidding:4.21.5.0+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-admob:4.22.1.0+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-amazon-publisher-services:4.9.8.2+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-applovin:4.11.10.1+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-chartboost:4.9.3.1+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-digital-turbine-exchange:4.8.2.3+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-google-bidding:4.22.1.0+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-hyprmx:4.6.0.3+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.4+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.0+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-inmobi:4.10.5.5+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-ironsource:4.7.3.1+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-meta-audience-network:4.6.14.0+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-mintegral:4.16.3.91+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-mobilefuse:4.1.4.4+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-pangle:4.4.9.1.3+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-tapjoy:4.12.11.1+@aar</package>
-    <package>com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.6.1+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-unity-ads:4.4.7.1+@aar</package>
+    <package>com.chartboost:chartboost-mediation-adapter-verve:4.2.17.0+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-vungle:4.6.12.1+@aar</package>
     <package>com.chartboost:chartboost-mediation-adapter-yahoo:4.1.4.0+@aar</package>
-    <package>com.chartboost:chartboost-mediation-sdk:4.3+</package>
-    <package>com.chartboost:chartboost-sdk:9.3.0</package>
+    <package>com.chartboost:chartboost-mediation-sdk:4.4+</package>
+    <package>com.chartboost:chartboost-sdk:9.3.1</package>
     <package>com.facebook.android:audience-network-sdk:6.14.0</package>
-    <package>com.fyber:marketplace-sdk:8.2.2</package>
-    <package>com.google.android.gms:play-services-ads:21.5.0</package>
+    <package>com.fyber:marketplace-sdk:8.2.3</package>
+    <package>com.google.android.gms:play-services-ads:22.1.0</package>
     <package>com.google.android.gms:play-services-ads-identifier:18.0.1</package>
     <package>com.google.android.gms:play-services-appset:16.0.2</package>
     <package>com.google.android.gms:play-services-base:18.1.0</package>
     <package>com.google.android.gms:play-services-basement:18.1.0</package>
     <package>com.google.guava:guava:31.1-android</package>
     <package>com.hyprmx.android:HyprMX-SDK:6.0.3</package>
-    <package>com.inmobi.monetization:inmobi-ads-kotlin:10.5.4</package>
-    <package>com.ironsource.sdk:mediationsdk:7.3.0</package>
+    <package>com.inmobi.monetization:inmobi-ads-kotlin:10.5.5</package>
+    <package>com.ironsource.sdk:mediationsdk:7.3.1</package>
+    <package>com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0</package>
     <package>com.mbridge.msdk.oversea:interstitialvideo:16.3.91</package>
     <package>com.mbridge.msdk.oversea:mbbanner:16.3.91</package>
     <package>com.mbridge.msdk.oversea:mbbid:16.3.91</package>
@@ -47,11 +50,19 @@
     <package>com.mbridge.msdk.oversea:same:16.3.91</package>
     <package>com.mbridge.msdk.oversea:videocommon:16.3.91</package>
     <package>com.mbridge.msdk.oversea:videojs:16.3.91</package>
+    <package>com.mobilefuse.sdk:mobilefuse-sdk-core:1.4.4</package>
     <package>com.pangle.global:ads-sdk:4.9.1.3</package>
+    <package>com.squareup.okhttp3:logging-interceptor:4.10.0</package>
+    <package>com.squareup.okhttp3:okhttp:4.10.0</package>
+    <package>com.squareup.retrofit2:converter-scalars:2.9.0</package>
+    <package>com.squareup.retrofit2:retrofit:2.9.0</package>
     <package>com.tapjoy:tapjoy-android-sdk:12.11.1</package>
-    <package>com.unity3d.ads:unity-ads:4.6.1</package>
+    <package>com.unity3d.ads:unity-ads:4.7.1</package>
     <package>com.vungle:publisher-sdk-android:6.12.1</package>
     <package>com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.4.0</package>
+    <package>net.pubnative:hybid.sdk:2.17.0</package>
+    <package>org.jetbrains.kotlin:kotlin-reflect:1.7.20</package>
+    <package>org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1</package>
   </packages>
   <files />
   <settings>

--- a/com.chartboost.mediation/Editor/Adapters/Templates/TemplateChartboostMediation.xml
+++ b/com.chartboost.mediation/Editor/Adapters/Templates/TemplateChartboostMediation.xml
@@ -9,6 +9,13 @@
         <!-- Chartboost Mediation Android SDK -->
         <androidPackage spec="com.chartboost:chartboost-mediation-sdk:%ANDROID_VERSION%+" />
         <androidPackage spec="androidx.localbroadcastmanager:localbroadcastmanager:1.1.0" />
+        <androidPackage spec="com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0" />
+        <androidPackage spec="org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1" />
+        <androidPackage spec="org.jetbrains.kotlin:kotlin-reflect:1.7.20" />
+        <androidPackage spec="com.squareup.okhttp3:okhttp:4.10.0" />
+        <androidPackage spec="com.squareup.okhttp3:logging-interceptor:4.10.0" />
+        <androidPackage spec="com.squareup.retrofit2:converter-scalars:2.9.0" />
+        <androidPackage spec="com.squareup.retrofit2:retrofit:2.9.0" />
 
         <!-- Google Play Services dependencies -->
         <androidPackage spec="com.google.android.gms:play-services-base:18.1.0"/>


### PR DESCRIPTION
# Description

* Added MobileFuse & Verve dependencies for iOS for all targets, this avoids crashes.
* Updated Android dependencies to their latest version.
* Updated Chartboost Mediation Dependencies with latest SDK dependencies.