### PR TITLE
[HB-6558] Remove UnityBannerAd Creation Option from Chartboost Mediation MenuItem

### DIFF
--- a/com.chartboost.mediation/Runtime/AdFormats/Banner/Unity/ChartboostMediationUnityBannerAd.Creator.cs
+++ b/com.chartboost.mediation/Runtime/AdFormats/Banner/Unity/ChartboostMediationUnityBannerAd.Creator.cs
@@ -8,7 +8,6 @@ namespace Chartboost.AdFormats.Banner.Unity
     public partial class ChartboostMediationUnityBannerAd : MonoBehaviour
     {
 #if UNITY_EDITOR
-        [MenuItem("Chartboost Mediation/UnityBannerAd/Create New")]
         [MenuItem("GameObject/Chartboost Mediation/UnityBannerAd")]
         public static void CreateAd()
         {


### PR DESCRIPTION
Only removes the MenuItem that is available through Chartboost Mediation menu. Doesn’t remove the option to create a UnityBannerAd using right-click in Hierarchy window