### PR TITLE
[HB-6541][HB-6646] Fix Calling Deprecated Functions And Features in All Platforms

### DIFF
--- a/com.chartboost.mediation.demo/ProjectSettings/ProjectSettings.asset
+++ b/com.chartboost.mediation.demo/ProjectSettings/ProjectSettings.asset
@@ -690,7 +690,13 @@ PlayerSettings:
   scriptingDefineSymbols:
     4: 
     7: 
-  additionalCompilerArguments: {}
+  additionalCompilerArguments:
+    1:
+    - -warnaserror
+    4:
+    - -warnaserror
+    7:
+    - -warnaserror
   platformArchitecture: {}
   scriptingBackend:
     Android: 1

--- a/com.chartboost.mediation/Documentation/images/create-unity-banner-ad.png.meta
+++ b/com.chartboost.mediation/Documentation/images/create-unity-banner-ad.png.meta
@@ -1,0 +1,96 @@
+fileFormatVersion: 2
+guid: 6369a437c8a324beb9639d981186a63c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.chartboost.mediation/Runtime/Banner/ChartboostMediationBannerIOS.cs
+++ b/com.chartboost.mediation/Runtime/Banner/ChartboostMediationBannerIOS.cs
@@ -64,6 +64,7 @@ namespace Chartboost.Banner
         }
 
         /// <inheritdoc cref="ChartboostMediationBannerBase.Remove"/>>
+        [Obsolete("Remove has been deprecated, please use Destroy instead.")]
         public override void Remove()
         {
             base.Remove();

--- a/com.chartboost.mediation/Runtime/Banner/IChartboostMediationBannerEvents.cs
+++ b/com.chartboost.mediation/Runtime/Banner/IChartboostMediationBannerEvents.cs
@@ -5,7 +5,6 @@ namespace Chartboost.Banner
     /// <summary>
     /// All Banner placement callbacks.
     /// </summary>
-    [Obsolete("ChartboostMediationBannerEvents has been deprecated, use the new ChartboostMediationBannerView API instead.")]
     public interface IChartboostMediationBannerEvents
     {
         /// <summary>

--- a/com.chartboost.mediation/Runtime/ChartboostMediation.cs
+++ b/com.chartboost.mediation/Runtime/ChartboostMediation.cs
@@ -26,10 +26,14 @@ namespace Chartboost
     /// </summary>
     public sealed class ChartboostMediation
     {
+        
+        #pragma warning disable CS0618
         private static readonly ChartboostMediationExternal _chartboostMediationExternal;
+        #pragma warning restore CS0618
 
         static ChartboostMediation() 
         {
+            #pragma warning disable CS0618
             #if UNITY_EDITOR
             _chartboostMediationExternal = new ChartboostMediationUnsupported();
             #elif UNITY_ANDROID
@@ -39,6 +43,7 @@ namespace Chartboost
             #else
             _chartboostMediationExternal = new ChartboostMediationUnsupported();
             #endif
+            #pragma warning restore CS0618
         }
         
         ~ChartboostMediation()
@@ -81,6 +86,7 @@ namespace Chartboost
 
         #region Interstitial Callbacks
         /// <inheritdoc cref="IChartboostMediationInterstitialEvents.DidLoadInterstitial"/>>
+        [Obsolete("DidLoadInterstitial has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementLoadEvent DidLoadInterstitial
         {
             add => _chartboostMediationExternal.DidLoadInterstitial += value;
@@ -88,6 +94,7 @@ namespace Chartboost
         }
 
         /// <inheritdoc cref="IChartboostMediationInterstitialEvents.DidShowInterstitial"/>>
+        [Obsolete("DidShowInterstitial has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidShowInterstitial
         {
             add => _chartboostMediationExternal.DidShowInterstitial += value;
@@ -95,6 +102,7 @@ namespace Chartboost
         }
         
         /// <inheritdoc cref="IChartboostMediationInterstitialEvents.DidCloseInterstitial"/>>
+        [Obsolete("DidCloseInterstitial has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidCloseInterstitial
         {
             add => _chartboostMediationExternal.DidCloseInterstitial += value;
@@ -102,6 +110,7 @@ namespace Chartboost
         }
 
         /// <inheritdoc cref="IChartboostMediationInterstitialEvents.DidClickInterstitial"/>>
+        [Obsolete("DidClickInterstitial has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidClickInterstitial
         {
             add => _chartboostMediationExternal.DidClickInterstitial += value;
@@ -109,6 +118,7 @@ namespace Chartboost
         }
         
         /// <inheritdoc cref="IChartboostMediationInterstitialEvents.DidRecordImpressionInterstitial"/>>
+        [Obsolete("DidRecordImpressionInterstitial has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidRecordImpressionInterstitial
         {
             add => _chartboostMediationExternal.DidRecordImpressionInterstitial += value;
@@ -118,6 +128,7 @@ namespace Chartboost
 
         #region Rewarded Callbacks
         /// <inheritdoc cref="IChartboostMediationRewardedEvents.DidLoadRewarded"/>>
+        [Obsolete("DidLoadRewarded has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementLoadEvent DidLoadRewarded
         {
             add => _chartboostMediationExternal.DidLoadRewarded += value;
@@ -125,6 +136,7 @@ namespace Chartboost
         }
         
         /// <inheritdoc cref="IChartboostMediationRewardedEvents.DidShowRewarded"/>>
+        [Obsolete("DidShowRewarded has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidShowRewarded
         {
             add => _chartboostMediationExternal.DidShowRewarded += value;
@@ -132,6 +144,7 @@ namespace Chartboost
         }
 
         /// <inheritdoc cref="IChartboostMediationRewardedEvents.DidCloseRewarded"/>>
+        [Obsolete("DidCloseRewarded has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidCloseRewarded
         {
             add => _chartboostMediationExternal.DidCloseRewarded += value;
@@ -139,6 +152,7 @@ namespace Chartboost
         }
 
         /// <inheritdoc cref="IChartboostMediationRewardedEvents.DidClickRewarded"/>>
+        [Obsolete("DidClickRewarded has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidClickRewarded
         {
             add => _chartboostMediationExternal.DidClickRewarded += value;
@@ -146,6 +160,7 @@ namespace Chartboost
         }
         
         /// <inheritdoc cref="IChartboostMediationRewardedEvents.DidRecordImpressionRewarded"/>>
+        [Obsolete("DidRecordImpressionRewarded has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidRecordImpressionRewarded
         {
             add => _chartboostMediationExternal.DidRecordImpressionRewarded += value;
@@ -153,6 +168,7 @@ namespace Chartboost
         }
         
         /// <inheritdoc cref="IChartboostMediationRewardedEvents.DidReceiveReward"/>>
+        [Obsolete("DidReceiveReward has been deprecated, use the new fullscreen API instead.")]
         public static event ChartboostMediationPlacementEvent DidReceiveReward
         {
             add => _chartboostMediationExternal.DidReceiveReward += value;
@@ -244,7 +260,8 @@ namespace Chartboost
             unityBannerAd.PlacementName = placementName;
             return unityBannerAd; 
         }
-
+        
+        [Obsolete("Init has been deprecated and will be removed in future versions of the SDK.")]
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
         private static void Init()
         {

--- a/com.chartboost.mediation/Runtime/FullScreen/ChartboostMediationFullScreenBase.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/ChartboostMediationFullScreenBase.cs
@@ -62,9 +62,8 @@ namespace Chartboost.FullScreen
     /// <summary>
     /// Chartboost Mediation interstitial ad object for unsupported platforms.
     /// </summary>
-    #pragma warning disable CS0618
+    [Obsolete("ChartboostMediationInterstitialUnsupported has been deprecated, use the new fullscreen API instead.")]
     internal class ChartboostMediationInterstitialUnsupported : ChartboostMediationFullScreenBase
-    #pragma warning restore CS0618
     {
         public ChartboostMediationInterstitialUnsupported(string placementName) : base(placementName)
         {

--- a/com.chartboost.mediation/Runtime/FullScreen/Interstitial/ChartboostMediationInterstitialAndroid.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Interstitial/ChartboostMediationInterstitialAndroid.cs
@@ -1,4 +1,5 @@
 #if UNITY_ANDROID
+using System;
 using Chartboost.Platforms.Android;
 using Chartboost.Utilities;
 using UnityEngine;
@@ -8,9 +9,8 @@ namespace Chartboost.FullScreen.Interstitial
     /// <summary>
     /// ChartboostMediation interstitial object for Android.
     /// </summary>
-    #pragma warning disable CS0618
+    [Obsolete("ChartboostMediationFullScreenBase has been deprecated, use the new fullscreen API instead.")]
     internal sealed class ChartboostMediationInterstitialAndroid : ChartboostMediationFullScreenBase
-    #pragma warning restore CS0618
     {
         private readonly AndroidJavaObject _androidAd;
         private readonly int _uniqueId;

--- a/com.chartboost.mediation/Runtime/FullScreen/Interstitial/ChartboostMediationInterstitialIOS.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Interstitial/ChartboostMediationInterstitialIOS.cs
@@ -7,6 +7,7 @@ namespace Chartboost.FullScreen.Interstitial
     /// <summary>
     /// Chartboost Mediation interstitial object for iOS.
     /// </summary>
+    [Obsolete("ChartboostMediationInterstitialIOS has been deprecated, use the new fullscreen API instead.")]
     internal sealed class ChartboostMediationInterstitialIOS : ChartboostMediationFullScreenBase
     {
         private readonly IntPtr _uniqueId;

--- a/com.chartboost.mediation/Runtime/FullScreen/Interstitial/IChartboostMediationInterstitialEvents.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Interstitial/IChartboostMediationInterstitialEvents.cs
@@ -5,7 +5,6 @@ namespace Chartboost.FullScreen.Interstitial
     /// <summary>
     /// All interstitial placement callbacks.
     /// </summary>
-    [Obsolete("IChartboostMediationInterstitialEvents has been deprecated, use the new fullscreen API instead.")]
     public interface IChartboostMediationInterstitialEvents
     {
         /// <summary>

--- a/com.chartboost.mediation/Runtime/FullScreen/Rewarded/ChartboostMediationRewardedAndroid.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Rewarded/ChartboostMediationRewardedAndroid.cs
@@ -1,4 +1,5 @@
 #if UNITY_ANDROID
+using System;
 using Chartboost.Platforms.Android;
 using Chartboost.Utilities;
 using UnityEngine;
@@ -8,9 +9,8 @@ namespace Chartboost.FullScreen.Rewarded
     /// <summary>
     /// Chartboost Mediation rewarded ad object for Android.
     /// </summary>
-    #pragma warning disable CS0618
+    [Obsolete("ChartboostMediationRewardedBase has been deprecated, use the new fullscreen API instead.")]
     internal sealed class ChartboostMediationRewardedAndroid : ChartboostMediationRewardedBase
-    #pragma warning restore CS0618
     {
         private readonly AndroidJavaObject _androidAd;
         private readonly int _uniqueId;

--- a/com.chartboost.mediation/Runtime/FullScreen/Rewarded/ChartboostMediationRewardedBase.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Rewarded/ChartboostMediationRewardedBase.cs
@@ -19,9 +19,8 @@ namespace Chartboost.FullScreen.Rewarded
     /// <summary>
     /// Chartboost Mediation rewarded ad object for unsupported platforms.
     /// </summary>
-    #pragma warning disable CS0618
+    [Obsolete("ChartboostMediationRewardedBase has been deprecated, use the new fullscreen API instead.")]
     internal sealed class ChartboostMediationRewardedUnsupported : ChartboostMediationRewardedBase
-    #pragma warning restore CS0618
     {
         internal override bool IsValid { get; set; }
 

--- a/com.chartboost.mediation/Runtime/FullScreen/Rewarded/ChartboostMediationRewardedIOS.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Rewarded/ChartboostMediationRewardedIOS.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 
 namespace Chartboost.FullScreen.Rewarded
 {
+    [Obsolete("ChartboostMediationRewardedIOS has been deprecated, use the new fullscreen API instead.")]
     internal sealed class ChartboostMediationRewardedIOS : ChartboostMediationRewardedBase
     {
         private readonly IntPtr _uniqueId;

--- a/com.chartboost.mediation/Runtime/FullScreen/Rewarded/IChartboostMediationRewardedEvents.cs
+++ b/com.chartboost.mediation/Runtime/FullScreen/Rewarded/IChartboostMediationRewardedEvents.cs
@@ -5,7 +5,6 @@ namespace Chartboost.FullScreen.Rewarded
     /// <summary>
     /// Interface implemented by Chartboost Mediation rewarded ads. 
     /// </summary>
-    [Obsolete("IChartboostMediationRewardedEvents has been deprecated, use the new fullscreen API instead.")]
     public interface IChartboostMediationRewardedEvents
     {
         /// <summary>

--- a/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.Callbacks.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.Callbacks.cs
@@ -1,4 +1,5 @@
 #if UNITY_ANDROID
+using System;
 using Chartboost.AdFormats.Banner;
 using Chartboost.AdFormats.Fullscreen;
 using Chartboost.Events;
@@ -177,28 +178,6 @@ namespace Chartboost.Platforms.Android
 
         }
 
-        #endregion
-
-        #region Banner Callbacks (deprecated)
-        internal class BannerEventListener : AndroidJavaProxy
-        {
-            private BannerEventListener() : base(GetQualifiedClassName("IBannerEventListener")) { }
-
-            public static readonly BannerEventListener Instance = new BannerEventListener();
-
-            private void DidLoadBanner(string placementName, string loadId, string auctionId, string partnerId, double price, string lineItemName, string lineItemId, string error) 
-                => EventProcessor.ProcessChartboostMediationLoadEvent(placementName,  loadId, auctionId, partnerId, price, lineItemName, lineItemId, error, _instance.DidLoadBanner);
-
-            private void DidClickBanner(string placementName) 
-                => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, null, _instance.DidClickBanner);
-
-            private void DidRecordImpression(string placementName) 
-                => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, null, _instance.DidRecordImpressionBanner);
-        }
-
-        public override event ChartboostMediationPlacementLoadEvent DidLoadBanner;
-        public override event ChartboostMediationPlacementEvent DidClickBanner;
-        public override event ChartboostMediationPlacementEvent DidRecordImpressionBanner;
         #endregion
     }
 }

--- a/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.Legacy.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.Legacy.cs
@@ -1,4 +1,5 @@
 #if UNITY_ANDROID
+using System;
 using Chartboost.Events;
 using UnityEngine;
 // ReSharper disable InconsistentNaming
@@ -31,10 +32,15 @@ namespace Chartboost.Platforms.Android
                 => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, null, _instance.DidRecordImpressionInterstitial);
         }
 
+        [Obsolete("DidLoadInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementLoadEvent DidLoadInterstitial;
+        [Obsolete("DidShowInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidShowInterstitial;
-        public override event ChartboostMediationPlacementEvent DidCloseInterstitial; 
+        [Obsolete("DidCloseInterstitial has been deprecated, use the new fullscreen API instead.")]
+        public override event ChartboostMediationPlacementEvent DidCloseInterstitial;
+        [Obsolete("DidClickInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidClickInterstitial;
+        [Obsolete("DidRecordImpressionInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidRecordImpressionInterstitial;
         #endregion
 
@@ -64,12 +70,43 @@ namespace Chartboost.Platforms.Android
                 => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, null, _instance.DidReceiveReward);
         }
 
+        [Obsolete("DidLoadRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementLoadEvent DidLoadRewarded;
+        [Obsolete("DidShowRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidShowRewarded;
+        [Obsolete("DidCloseRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidCloseRewarded;
+        [Obsolete("DidClickRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidClickRewarded;
+        [Obsolete("DidRecordImpressionRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidRecordImpressionRewarded;
+        [Obsolete("DidReceiveReward has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidReceiveReward;
+        #endregion
+        
+        #region Banner Callbacks
+        internal class BannerEventListener : AndroidJavaProxy
+        {
+            private BannerEventListener() : base(GetQualifiedClassName("IBannerEventListener")) { }
+
+            public static readonly BannerEventListener Instance = new BannerEventListener();
+
+            private void DidLoadBanner(string placementName, string loadId, string auctionId, string partnerId, double price, string lineItemName, string lineItemId, string error) 
+                => EventProcessor.ProcessChartboostMediationLoadEvent(placementName,  loadId, auctionId, partnerId, price, lineItemName, lineItemId, error, _instance.DidLoadBanner);
+
+            private void DidClickBanner(string placementName) 
+                => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, null, _instance.DidClickBanner);
+
+            private void DidRecordImpression(string placementName) 
+                => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, null, _instance.DidRecordImpressionBanner);
+        }
+
+        [Obsolete("DidLoadBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
+        public override event ChartboostMediationPlacementLoadEvent DidLoadBanner;
+        [Obsolete("DidClickBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
+        public override event ChartboostMediationPlacementEvent DidClickBanner;
+        [Obsolete("DidRecordImpressionBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
+        public override event ChartboostMediationPlacementEvent DidRecordImpressionBanner;
         #endregion
     }
 }

--- a/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/Android/ChartboostMediationAndroid.cs
@@ -1,6 +1,5 @@
 #if UNITY_ANDROID
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Chartboost.AdFormats.Banner;
 using Chartboost.Events;
@@ -43,12 +42,11 @@ namespace Chartboost.Platforms.Android
 
         internal static AndroidJavaClass GetNativeSDK() => new AndroidJavaClass(GetQualifiedNativeClassName("HeliumSdk"));
 
+        [Obsolete("Init has been deprecated and will be removed in future versions of the SDK.")]
         public override void Init()
         {
             base.Init();
-            #pragma warning disable CS0618
             InitWithAppIdAndSignature(ChartboostMediationSettings.AndroidAppId, ChartboostMediationSettings.AndroidAppSignature);
-            #pragma warning restore CS0618
         }
 
         [Obsolete("InitWithAppIdAndSignature has been deprecated, please use StartWithOptions instead")]

--- a/com.chartboost.mediation/Runtime/Platforms/ChartboostMediationExternal.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/ChartboostMediationExternal.cs
@@ -15,9 +15,7 @@ using Logger = Chartboost.Utilities.Logger;
 
 namespace Chartboost.Platforms
 {
-    #pragma warning disable CS0618
     internal abstract class ChartboostMediationExternal : IChartboostMediationLifeCycle, IChartboostMediationInterstitialEvents, IChartboostMediationRewardedEvents, IChartboostMediationBannerEvents
-    #pragma warning restore CS0618
     {
         public static bool IsInitialized { get; protected set; }
         
@@ -44,6 +42,7 @@ namespace Chartboost.Platforms
         
         /// Initializes the Chartboost Mediation plugin.
         /// This must be called before using any other Chartboost Mediation features.
+        [Obsolete("Init has been deprecated and will be removed in future versions of the SDK.")]
         public virtual void Init() 
             => Logger.Log(LogTag, "Init - Attempting to Initialize Chartboost Mediation SDK from ChartboostMediationSettings.");
 
@@ -126,18 +125,15 @@ namespace Chartboost.Platforms
             }
         }
         
- #pragma warning disable CS0618
+        [Obsolete("GetBannerAd has been deprecated and will be removed in future versions, use GetBannerView instead.")]
         public ChartboostMediationBannerAd GetBannerAd(string placementName, ChartboostMediationBannerAdSize size)
- #pragma warning restore CS0618
         {
             Logger.Log(LogTag, $"GetBannerAd at placement: {placementName}");
             if (!CanFetchAd(placementName))
                 return null;
             try
             {
- #pragma warning disable CS0618
                 return new ChartboostMediationBannerAd(placementName, size);
- #pragma warning restore CS0618
             }
             catch (Exception e)
             {
@@ -146,7 +142,7 @@ namespace Chartboost.Platforms
             }
         }
         
-        [Obsolete]
+        [Obsolete("GetInitializationOptions has been deprecated and replaced with StartWithOptions.")]
         protected static string[] GetInitializationOptions()
         {
             string GetEnumDescription(Enum value)
@@ -177,31 +173,45 @@ namespace Chartboost.Platforms
             return initOptions;
         }
 
-#pragma warning disable 67
+        #pragma warning disable 67
         // Life-cycle
         public virtual event ChartboostMediationEvent DidStart;
         public virtual event ChartboostMediationILRDEvent DidReceiveImpressionLevelRevenueData;
         public virtual event ChartboostMediationPartnerInitializationEvent DidReceivePartnerInitializationData;
         
         // Interstitials
+        [Obsolete("DidLoadInterstitial has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementLoadEvent DidLoadInterstitial;
+        [Obsolete("DidShowInterstitial has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidShowInterstitial;
+        [Obsolete("DidCloseInterstitial has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidCloseInterstitial;
+        [Obsolete("DidClickInterstitial has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidClickInterstitial;
+        [Obsolete("DidRecordImpressionInterstitial has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidRecordImpressionInterstitial;
 
         // Rewarded Videos
+        [Obsolete("DidLoadRewarded has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementLoadEvent DidLoadRewarded;
+        [Obsolete("DidShowRewarded has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidShowRewarded;
+        [Obsolete("DidCloseRewarded has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidCloseRewarded;
+        [Obsolete("DidClickRewarded has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidClickRewarded;
+        [Obsolete("DidRecordImpressionRewarded has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidRecordImpressionRewarded;
+        [Obsolete("DidReceiveReward has been deprecated, use the new fullscreen API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidReceiveReward;
 
         // Banners
+        [Obsolete("DidLoadBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
         public virtual event ChartboostMediationPlacementLoadEvent DidLoadBanner;
+        [Obsolete("DidClickBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidClickBanner;
+        [Obsolete("DidRecordImpressionBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
         public virtual event ChartboostMediationPlacementEvent DidRecordImpressionBanner;
-#pragma warning restore 67
+        #pragma warning restore 67
     }
 }

--- a/com.chartboost.mediation/Runtime/Platforms/ChartboostMediationUnsupported.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/ChartboostMediationUnsupported.cs
@@ -6,6 +6,7 @@ using Chartboost.Results;
 
 namespace Chartboost.Platforms
 {
+    [Obsolete("IChartboostMediationInterstitialEvents, IChartboostMediationRewardedEvents, IChartboostMediationBannerEvents has been deprecated, use the new fullscreen API instead.")]
     internal class ChartboostMediationUnsupported : ChartboostMediationExternal
     {
         private static string _userIdentifier;
@@ -16,6 +17,7 @@ namespace Chartboost.Platforms
             LogTag = "ChartboostMediation (Unsupported)";
         }
 
+        [Obsolete("Init has been deprecated and will be removed in future versions of the SDK.")]
         public override void Init()
         {
             base.Init();

--- a/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.Callbacks.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.Callbacks.cs
@@ -58,10 +58,6 @@ namespace Chartboost.Platforms.IOS
         [DllImport("__Internal")]
         private static extern void _setBannerAdCallbacks(ExternChartboostMediationBannerAdEvent bannerAdEvents);
 
-        
-        [DllImport("__Internal")]
-        private static extern void _setBannerCallbacks(ExternChartboostMediationPlacementLoadEvent DidLoadCallback, ExternChartboostMediationPlacementEvent DidRecordImpression, ExternChartboostMediationPlacementEvent DidClickCallback);
-
         #region LifeCycle Callbacks
         [MonoPInvokeCallback(typeof(ExternChartboostMediationEvent))]
         private static void ExternDidStart(string error) 
@@ -127,26 +123,8 @@ namespace Chartboost.Platforms.IOS
         private static void FullscreenAdEvents(long adHashCode, int eventType, string code, string message) 
             => EventProcessor.ProcessFullscreenEvent(adHashCode, eventType, code, message);
         #endregion
-        
-        #region Banner Callbacks (deprecated)
-        [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementLoadEvent))]
-        private static void ExternDidLoadBanner(string placementName, string loadId, string auctionId, string partnerId, double price, string lineItemName, string lineItemId, string error) 
-            => EventProcessor.ProcessChartboostMediationLoadEvent(placementName, loadId, auctionId, partnerId, price, lineItemName, lineItemId, error, _instance.DidLoadBanner);
 
-        [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementEvent))]
-        private static void ExternDidClickBanner(string placementName, string error) 
-            => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, error, _instance.DidClickBanner);
-        
-        [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementEvent))]
-        private static void ExternDidRecordImpressionBanner(string placementName, string error) 
-            => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, error,  _instance.DidRecordImpressionBanner);
-
-        public override event ChartboostMediationPlacementLoadEvent DidLoadBanner;
-        public override event ChartboostMediationPlacementEvent DidClickBanner;
-        public override event ChartboostMediationPlacementEvent DidRecordImpressionBanner;
-        #endregion
-
-        #region Baner Callbacks
+        #region Banner Callbacks
         public delegate void ExternChartboostMediationBannerAdLoadResultEvent(int hashCode, IntPtr adHashCode, string loadId, string metricsJson, string code, string message);
         
         [MonoPInvokeCallback(typeof(ExternChartboostMediationBannerAdLoadResultEvent))]

--- a/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.Legacy.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.Legacy.cs
@@ -1,4 +1,5 @@
 #if UNITY_IOS
+using System;
 using System.Runtime.InteropServices;
 using AOT;
 using Chartboost.Events;
@@ -17,6 +18,9 @@ namespace Chartboost.Platforms.IOS
         private static extern void _setRewardedCallbacks(ExternChartboostMediationPlacementLoadEvent DidLoadCallback,
             ExternChartboostMediationPlacementEvent DidShowCallback, ExternChartboostMediationPlacementEvent DidCloseCallback, ExternChartboostMediationPlacementEvent DidClickCallback,
             ExternChartboostMediationPlacementEvent DidRecordImpression, ExternChartboostMediationPlacementEvent DidReceiveReward);
+        
+        [DllImport("__Internal")]
+        private static extern void _setBannerCallbacks(ExternChartboostMediationPlacementLoadEvent DidLoadCallback, ExternChartboostMediationPlacementEvent DidRecordImpression, ExternChartboostMediationPlacementEvent DidClickCallback);
         
         #region Interstitial Callbacks
         [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementLoadEvent))]
@@ -39,10 +43,15 @@ namespace Chartboost.Platforms.IOS
         private static void ExternDidRecordImpressionInterstitial(string placementName, string error)
             => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, error, _instance.DidRecordImpressionInterstitial);
         
+        [Obsolete("DidLoadInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementLoadEvent DidLoadInterstitial;
+        [Obsolete("DidShowInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidShowInterstitial;
+        [Obsolete("DidCloseInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidCloseInterstitial;
+        [Obsolete("DidClickInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidClickInterstitial;
+        [Obsolete("DidRecordImpressionInterstitial has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidRecordImpressionInterstitial;
         #endregion
 
@@ -71,12 +80,39 @@ namespace Chartboost.Platforms.IOS
         private static void ExternDidReceiveReward(string placementName, string error) 
             => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, error, _instance.DidReceiveReward);
         
+        [Obsolete("DidLoadRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementLoadEvent DidLoadRewarded;
+        [Obsolete("DidShowRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidShowRewarded;
+        [Obsolete("DidCloseRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidCloseRewarded;
+        [Obsolete("DidClickRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidClickRewarded;
+        [Obsolete("DidRecordImpressionRewarded has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidRecordImpressionRewarded;
+        [Obsolete("DidReceiveReward has been deprecated, use the new fullscreen API instead.")]
         public override event ChartboostMediationPlacementEvent DidReceiveReward;
+        #endregion
+        
+        #region Banner Callbacks
+        [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementLoadEvent))]
+        private static void ExternDidLoadBanner(string placementName, string loadId, string auctionId, string partnerId, double price, string lineItemName, string lineItemId, string error) 
+            => EventProcessor.ProcessChartboostMediationLoadEvent(placementName, loadId, auctionId, partnerId, price, lineItemName, lineItemId, error, _instance.DidLoadBanner);
+
+        [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementEvent))]
+        private static void ExternDidClickBanner(string placementName, string error) 
+            => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, error, _instance.DidClickBanner);
+        
+        [MonoPInvokeCallback(typeof(ExternChartboostMediationPlacementEvent))]
+        private static void ExternDidRecordImpressionBanner(string placementName, string error) 
+            => EventProcessor.ProcessChartboostMediationPlacementEvent(placementName, error,  _instance.DidRecordImpressionBanner);
+
+        [Obsolete("DidLoadBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
+        public override event ChartboostMediationPlacementLoadEvent DidLoadBanner;
+        [Obsolete("DidClickBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
+        public override event ChartboostMediationPlacementEvent DidClickBanner;
+        [Obsolete("DidRecordImpressionBanner has been deprecated, use the new ChartboostMediationBannerView API instead.")]
+        public override event ChartboostMediationPlacementEvent DidRecordImpressionBanner;
         #endregion
     }
 }

--- a/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.cs
+++ b/com.chartboost.mediation/Runtime/Platforms/IOS/ChartboostMediationIOS.cs
@@ -82,12 +82,14 @@ namespace Chartboost.Platforms.IOS
             _setBannerAdCallbacks(BannerAdEvents);
         }
 
+        [Obsolete("Init has been deprecated and will be removed in future versions of the SDK.")]
         public override void Init()
         {
             base.Init();
             InitWithAppIdAndSignature(ChartboostMediationSettings.IOSAppId, ChartboostMediationSettings.IOSAppSignature);
         }
 
+        [Obsolete("InitWithAppIdAndSignature has been deprecated, please use StartWithOptions instead")]
         public override void InitWithAppIdAndSignature(string appId, string appSignature)
         {
             base.InitWithAppIdAndSignature(appId, appSignature);


### PR DESCRIPTION
# Title
[HB-6541][HB6646]  Fix Calling Deprecated Functions

# Description

The Unity SDK has internal functions that call deprecated functions (and wrap them with warning-disable). ChartboostMediationAndroid.cs, for example.  This feels like either it should be converted to use the non-deprecated versions, or the function making these calls should also be deprecated. IOS calls have been fixed so they do not trigger internal warnings. We have also enabled `-warnaserror` to detect this issues in the future.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactor / Maintenance (refactoring code to be cleaner/easier to maintain)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


[HB-6541]: https://chartboost.atlassian.net/browse/HB-6541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ