### PR TITLE
[HB-6642] Update Usage of Getting Screen Scale on iOS17+

### DIFF
--- a/com.chartboost.mediation/Runtime/Plugins/iOS/ChartboostMediationUnityBridge.mm
+++ b/com.chartboost.mediation/Runtime/Plugins/iOS/ChartboostMediationUnityBridge.mm
@@ -616,7 +616,27 @@ char * _chartboostMediationGetUserIdentifier()
 }
 
 float _chartboostMediationGetUIScaleFactor() {
-    // TODO: https://github.com/ChartBoost/ios-helium-sdk/pull/1314
+    // `UIScreen.main` was deprecated in iOS 16. Apple doc:
+    //   https://developer.apple.com/documentation/uikit/uiscreen/1617815-main
+    // Since `UIScreen.main` has been working correctly at least up to iOS 16, the custom
+    // implementation only targets iOS 17+, not iOS 13+.
+    if (@available(iOS 17.0, *)) {
+        NSSet<UIScene*> *connectedScenes = UIApplication.sharedApplication.connectedScenes;
+        NSArray *activationStates = @[@(UISceneActivationStateForegroundActive), @(UISceneActivationStateForegroundInactive), @(UISceneActivationStateBackground), @(UISceneActivationStateUnattached)];
+        for (NSNumber *activationState in activationStates) {
+            UISceneActivationState state = (UISceneActivationState)activationState.integerValue;
+            for (UIScene* connectedScene in connectedScenes) {
+                UIWindowScene *windowScene = (UIWindowScene*)connectedScene;
+                if (windowScene) {
+                    if (windowScene.activationState == state) {
+                        return windowScene.screen.scale;
+                    }
+                }
+            }
+        }
+    }
+
+    // fallback
     return UIScreen.mainScreen.scale;
 }
 


### PR DESCRIPTION
# Title
[HB-6642] Replace usage of `UIScreen.Main.Scale` on native IOS bridge since it is marked deprecated 

# Description

`UIScreen.main` is deprecated.  Mimic'd the Swift implementation in the iOS native SDK as closely as possible from https://github.com/ChartBoost/ios-helium-sdk/pull/1314.

## Type of change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactor / Maintenance (refactoring code to be cleaner/easier to maintain)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


[HB-6642]: https://chartboost.atlassian.net/browse/HB-6642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ