### PR TITLE
[HB-6718] Provide Task Continuation Extension for Main Thread

### DIFF
--- a/com.chartboost.mediation/Runtime/Utilities/AndroidConstants.cs
+++ b/com.chartboost.mediation/Runtime/Utilities/AndroidConstants.cs
@@ -88,7 +88,7 @@ namespace Chartboost.Utilities
         internal const string PropertyAuctionId = "auction-id";
         internal const string PropertyLineItemId = "line_item_id";
         internal const string PropertyLineItemName = "line_item_name";
-        internal const string PropertyPrice = "line_item_name";
+        internal const string PropertyPrice = "price";
         internal const string PropertyName = "name";
         internal const string PropertyWidth = "width";
         internal const string PropertyHeight = "height";


### PR DESCRIPTION
# Title
[HB-6718] Provide Task Continuation Extension for Main Thread

# Description

# Description

Currently, C# provides future continuations in the form of `ContinueWith`, as seen here: [Task.ContinueWith Method (System.Threading.Tasks)](https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.task.continuewith?view=net-7.0)  however, this does not run on the main thread unless specified. This is problematic for Mediation since we provide functionality that requires to run on the main thread. Developers can ensure this is done by calling the methods from a C#/Unity scenario like MonoBehaviors and Unity related environments. However, if they utilize the base ContinueWith method, it will run into a different thread causing possible crashes. 

This PR contains changes to provide developers with the option to utilize Task Continuation extensions that will run on the main thread.

## Type of change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Refactor / Maintenance (refactoring code to be cleaner/easier to maintain)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


[HB-6718]: https://chartboost.atlassian.net/browse/HB-6718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ