### PR TITLE
[HB-6747] Passing Context when Getting Partner Consent in Android

### DIFF
--- a/com.chartboost.mediation/Runtime/Consent/PartnerConsentAndroid.cs
+++ b/com.chartboost.mediation/Runtime/Consent/PartnerConsentAndroid.cs
@@ -10,8 +10,10 @@ namespace Chartboost.Consent
     {
         private static AndroidJavaObject GetNativePartnerConsents()
         {
+            using var unityPlayer = new AndroidJavaClass(AndroidConstants.ClassUnityPlayer);
+            using var activity = unityPlayer.GetStatic<AndroidJavaObject>(AndroidConstants.PropertyCurrentActivity);
             using var native = ChartboostMediationAndroid.GetNativeSDK();
-            return native.CallStatic<AndroidJavaObject>(AndroidConstants.FunGetPartnerConsents);
+            return native.CallStatic<AndroidJavaObject>(AndroidConstants.FunGetPartnerConsents, activity);
         }
 
         /// <inheritdoc cref="GetPartnerIdToConsentGivenDictionaryCopy"/>


### PR DESCRIPTION
# Title
[HB-6747] Passing Context when Getting Partner Consent in Android

# Description

Passing context when getting partner consent in Android. This is required so it can values can be fetched before initialization.

## Type of change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactor / Maintenance (refactoring code to be cleaner/easier to maintain)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


[HB-6747]: https://chartboost.atlassian.net/browse/HB-6747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ